### PR TITLE
ui: mobile thread status legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - UI: mobile thread list shows more of the title by allowing 2-line titles while keeping the date visible.
 
 ### UX
+- UI: on mobile, the thread status legend is now available via a `?` button (iOS doesn't reliably show `title` tooltips).
 - Thread list is now sorted by most recent activity (Pocket-observed activity first, then upstream timestamps, then createdAt fallback).
 
 ### CLI / Update


### PR DESCRIPTION
## What
Add a mobile-friendly thread status legend (`?` button) in the thread list header.

## Why
On iOS, `title` tooltips are unreliable and the existing legend text was hidden on small screens. This makes the idle/working/blocked dots discoverable and keeps the header compact.

## How to test
1. Open the Threads list on an iPhone-sized viewport.
2. Tap `?` next to Threads.
3. Verify the legend modal shows idle/working/blocked meanings and closes via backdrop tap or the close button.
4. Desktop: legend remains inline.

## Risk
Low. UI-only change scoped to `Home.svelte`.

## Rollback
Revert commit `7479026`.