### PR TITLE
fix: thread list compatibility + token clipboard

### DIFF
--- a/bin/codex-pocket
+++ b/bin/codex-pocket
@@ -515,7 +515,14 @@ cmd_doctor() {
 
 cmd_token() {
   read_config
-  token
+  local tok
+  tok="$(token | tr -d '\n')"
+  echo "$tok"
+  # Convenience: copy to clipboard on macOS (stderr so stdout stays script-friendly).
+  if command -v pbcopy >/dev/null 2>&1; then
+    printf %s "$tok" | pbcopy || true
+    echo "Copied token to clipboard." >&2
+  fi
 }
 
 cmd_urls() {

--- a/services/local-orbit/src/index.ts
+++ b/services/local-orbit/src/index.ts
@@ -898,8 +898,17 @@ async function injectThreadTitles(msg: Record<string, unknown>): Promise<void> {
   }
 
   // Requests may include `method`, but responses generally don't. Handle both.
-  if ((method === "thread/list" || !method) && result?.data && Array.isArray(result.data)) {
-    for (const t of result.data) applyToThread(t);
+  if (method === "thread/list" || !method) {
+    const rawList: any[] = Array.isArray(result?.data)
+      ? result.data
+      : Array.isArray(result?.threads)
+        ? result.threads
+        : Array.isArray(result?.items)
+          ? result.items
+          : Array.isArray(result)
+            ? result
+            : [];
+    for (const t of rawList) applyToThread(t);
     return;
   }
 


### PR DESCRIPTION
Fixes empty thread list when Codex app-server returns a non-"data" list shape (supports {threads:[]}, {items:[]}, or bare array), and makes `codex-pocket token` also copy the token to clipboard on macOS (message to stderr; token still printed to stdout).