### PR TITLE
ci: add regression guard for subscription loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
       - name: Build UI
         run: bun run build
 
+      - name: Regression guards
+        shell: bash
+        run: |
+          set -euo pipefail
+          bun scripts/ci/regression-guards.ts
+
       - name: Start server (local-orbit)
         shell: bash
         run: |

--- a/scripts/ci/regression-guards.ts
+++ b/scripts/ci/regression-guards.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+
+function fail(msg: string): never {
+  console.error(`regression-guards: FAIL: ${msg}`);
+  process.exit(1);
+}
+
+function assertNoReactiveSetState(opts: { file: string; varName: string }) {
+  const text = readFileSync(opts.file, "utf8");
+
+  // We had a production regression where `let x = $state<Set<string>>(new Set())` lived
+  // inside an effect that both read and overwrote it, creating a feedback loop that made
+  // the thread list appear empty/unusable. Guard against reintroducing this pattern.
+  const re = new RegExp(String.raw`\\blet\\s+${opts.varName}\\s*=\\s*\\$state\\s*<\\s*Set\\s*<`, "m");
+  if (re.test(text)) {
+    fail(`${opts.file} declares \`${opts.varName}\` as reactive $state<Set<...>>. Use a plain Set for bookkeeping inside effects.`);
+  }
+}
+
+assertNoReactiveSetState({
+  file: "src/routes/Home.svelte",
+  varName: "listSubscribed",
+});
+
+console.log("regression-guards: OK");
+


### PR DESCRIPTION
Adds a small CI guard that fails if Home.svelte reintroduces reactive <Set<...>> bookkeeping for list thread subscriptions (this caused an empty/unstable thread list regression).