### PR TITLE
docs: record thread list regression + safeguards

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -9,6 +9,7 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 ## Recently Done
 
 - CI: added an explicit `/admin/validate` smoke check (auth required).
+- CI: added small regression guards to prevent known UI footguns (e.g. thread list subscription loop).
 - CLI: `start` now falls back to background mode if the launchd plist is missing.
 - CLI: improved owned-process detection by also checking process CWD (helps kill stale listeners from older installs where the command line is just `bun run src/index.ts`).
 - Update regression: `scripts/test-update-flow.sh` now runs in restricted/offline environments (seeds `node_modules`, wraps Bun cache dir, uses more portable cleanup).
@@ -31,6 +32,7 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 - UI: thread list mobile density improved (2-line titles, date preserved).
 - UI: thread list now includes quick export/share actions (md + json) without opening the thread.
 - UI: message actions menu (copy, copy markdown, copy quoted, copy from here) + thread-level “copy last 20”.
+- UI: fixed a thread list instability regression caused by subscription bookkeeping inside an effect (could manifest as empty/unstable thread list).
 
 ## P0 (Stability)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 
 - CLI: added `codex-pocket self-test` and expanded `smoke-test` to cover the NDJSON events replay endpoint (helps catch “blank threads” regressions).
 - UI: harden thread list parsing/normalization so upstream `thread/list` response shape changes (nested `data`, `thread_id`) don't collapse the list to empty.
+- UI: fixed a thread list instability regression where list subscription bookkeeping used reactive `$state<Set<...>>` and could create an effect feedback loop (manifesting as an empty/unstable thread list).
+- Repo/CI: remove `.agents/` artifacts from git and add a CI regression guard to prevent reintroducing the thread list subscription loop pattern.
 - UI: message-level **copy** button (with a fallback clipboard implementation for non-HTTPS origins).
 - UI: thread export now supports both Markdown (`.md`) and JSON (`.json`).
 - UI: thread share now prefers sharing a real file on iOS (Web Share API `files`), falling back to text/copy/download.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -9,6 +9,7 @@ The workflow is defined in:
 
 - Installs dependencies with Bun
 - Builds the UI (Vite)
+- Runs small regression guards (fast static checks) to prevent known UI footguns
 - Starts `local-orbit` in CI mode (no Anchor autostart)
 - Verifies:
   - `GET /health` returns OK
@@ -19,6 +20,14 @@ The workflow is defined in:
     - SPA routes (`/app`) serve `index.html` with `Cache-Control: no-store`
     - Hashed assets serve `Cache-Control: ... immutable`
   - Events endpoint returns NDJSON
+
+## Regression Guards
+
+The workflow also runs `scripts/ci/regression-guards.ts`.
+
+These are intentionally small, targeted checks that catch regressions that are easy to reintroduce but hard to
+detect with a generic smoke test. Example: a past thread-list regression where reactive state bookkeeping inside
+an effect created a feedback loop and made the thread list appear empty/unusable.
 
 ## Does CI Cost Money?
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -31,6 +31,11 @@ bun run build
 
 Output goes to `dist/`.
 
+## Repo Hygiene
+
+Agent artifacts are local-only. Do not commit agent prompts, notes, or rule sets.
+Ignored by default: `.agents/`, `AGENT*.md`, `agent*.md`, `.agent/`, `prompts/`, `notes/`.
+
 ## Run Local-Orbit (server)
 
 Local-Orbit requires an access token.


### PR DESCRIPTION
Updates CHANGELOG/BACKLOG and CI/DEV docs to document the thread list subscription-loop regression, the new CI regression guard, and agent-artifact repo hygiene.