### PR TITLE
cli: detach background start to prevent immediate-exit

### DIFF
--- a/bin/codex-pocket
+++ b/bin/codex-pocket
@@ -650,28 +650,47 @@ cmd_start() {
     host="$(config_host)"
     local port
     port="$(config_port)"
-    # Use nohup so the service survives when started from a non-interactive shell
-    # (common during update/install flows). This was the root cause of "it started
-    # and then immediately died" reports.
-    nohup env \
-      ZANE_LOCAL_TOKEN="$(token)" \
-      ZANE_LOCAL_CONFIG_JSON="$CONFIG_JSON" \
-      ZANE_LOCAL_HOST="$host" \
-      ZANE_LOCAL_PORT="$port" \
-      ZANE_LOCAL_DB="$(db_path)" \
-      ZANE_LOCAL_RETENTION_DAYS="$(retention_days)" \
-      ZANE_LOCAL_PUBLIC_ORIGIN="$pub" \
-      ZANE_LOCAL_UI_DIST_DIR="$APP_DIR/app/dist" \
-      ZANE_LOCAL_ANCHOR_CWD="$APP_DIR/app/services/anchor" \
-      ZANE_LOCAL_ANCHOR_LOG="$APP_DIR/anchor.log" \
-      ANCHOR_HOST="127.0.0.1" \
-      ANCHOR_PORT="$aport" \
-      ZANE_LOCAL_ANCHOR_CMD="$bun_bin" \
-      ZANE_LOCAL_AUTOSTART_ANCHOR="1" \
-      "$bun_bin" run "$APP_DIR/app/services/local-orbit/src/index.ts" >>"$APP_DIR/server.log" 2>&1 </dev/null &
-    # `disown` isn't available in all shells; nohup does the heavy lifting.
-    disown >/dev/null 2>&1 || true
-    echo "$!" >"$PID_FILE"
+
+    # Start the service detached from the caller session.
+    #
+    # On macOS we can't rely on `setsid`, and this CLI is often invoked from shells
+    # that may not have job control (install/update helpers, automation runners, etc.).
+    # Use Python's `start_new_session=True` to ensure the service survives the parent
+    # process exiting. This avoids "it started and then immediately died" regressions.
+    local pid
+    pid="$(
+      env \
+        ZANE_LOCAL_TOKEN="$(token)" \
+        ZANE_LOCAL_CONFIG_JSON="$CONFIG_JSON" \
+        ZANE_LOCAL_HOST="$host" \
+        ZANE_LOCAL_PORT="$port" \
+        ZANE_LOCAL_DB="$(db_path)" \
+        ZANE_LOCAL_RETENTION_DAYS="$(retention_days)" \
+        ZANE_LOCAL_PUBLIC_ORIGIN="$pub" \
+        ZANE_LOCAL_UI_DIST_DIR="$APP_DIR/app/dist" \
+        ZANE_LOCAL_ANCHOR_CWD="$APP_DIR/app/services/anchor" \
+        ZANE_LOCAL_ANCHOR_LOG="$APP_DIR/anchor.log" \
+        ANCHOR_HOST="127.0.0.1" \
+        ANCHOR_PORT="$aport" \
+        ZANE_LOCAL_ANCHOR_CMD="$bun_bin" \
+        ZANE_LOCAL_AUTOSTART_ANCHOR="1" \
+        python3 - "$APP_DIR/server.log" "$bun_bin" "$APP_DIR/app/services/local-orbit/src/index.ts" <<'PY'
+import os, sys, subprocess
+log_path, bun_bin, entry = sys.argv[1], sys.argv[2], sys.argv[3]
+os.makedirs(os.path.dirname(log_path), exist_ok=True)
+with open(log_path, "ab", buffering=0) as f:
+  p = subprocess.Popen(
+    [bun_bin, "run", entry],
+    stdin=subprocess.DEVNULL,
+    stdout=f,
+    stderr=subprocess.STDOUT,
+    env=os.environ.copy(),
+    start_new_session=True,
+  )
+  print(p.pid)
+PY
+    )"
+    echo "$pid" >"$PID_FILE"
     echo "Started (background pid: $(cat "$PID_FILE"))"
     local base
     base="$(base_url)"


### PR DESCRIPTION
Fixes a reliability issue where background-mode service processes could die when the parent shell exits (common during update/install helpers). Uses python3 start_new_session=True to daemonize local-orbit in fallback background mode.