### PR TITLE
docs: note background start detachment fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 ## Unreleased
 
 - CLI: added `codex-pocket self-test` and expanded `smoke-test` to cover the NDJSON events replay endpoint (helps catch “blank threads” regressions).
+- CLI: background-mode start is now fully detached (prevents "service starts then immediately dies" when invoked from install/update helpers).
 - UI: harden thread list parsing/normalization so upstream `thread/list` response shape changes (nested `data`, `thread_id`) don't collapse the list to empty.
 - UI: fixed a thread list instability regression where list subscription bookkeeping used reactive `$state<Set<...>>` and could create an effect feedback loop (manifesting as an empty/unstable thread list).
 - Repo/CI: remove `.agents/` artifacts from git and add a CI regression guard to prevent reintroducing the thread list subscription loop pattern.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -93,6 +93,9 @@ codex-pocket restart
 codex-pocket self-test
 ```
 
+If the service repeatedly becomes unreachable shortly after starting, confirm you are on the latest version (some older
+background-start paths were not fully detached from the parent process).
+
 ### Tailscale Not Found
 
 Codex Pocket expects Tailscale for tailnet-only access.


### PR DESCRIPTION
Updates CHANGELOG + troubleshooting docs to reflect the background-mode start detachment fix (addresses intermittent 'service not reachable' right after update).