### PR TITLE
cli: smoke-test verifies /app + main bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 ## Unreleased
 
 - CLI: added `codex-pocket self-test` and expanded `smoke-test` to cover the NDJSON events replay endpoint (helps catch “blank threads” regressions).
+- CLI: smoke-test now also verifies `/app` serves HTML and the main JS bundle is fetchable (catches "blank app" incidents when the service is unhealthy or UI dist is mismatched).
 - CLI: background-mode start is now fully detached (prevents "service starts then immediately dies" when invoked from install/update helpers).
 - UI: harden thread list parsing/normalization so upstream `thread/list` response shape changes (nested `data`, `thread_id`) don't collapse the list to empty.
 - UI: fixed a thread list instability regression where list subscription bookkeeping used reactive `$state<Set<...>>` and could create an effect feedback loop (manifesting as an empty/unstable thread list).

--- a/bin/codex-pocket
+++ b/bin/codex-pocket
@@ -890,6 +890,39 @@ cmd_smoke_test() {
   fi
   echo "PASS: /health"
 
+  # 1.5) /app should serve the SPA index.html and its main JS bundle should be fetchable.
+  # This catches "service is up, but the web app is blank" issues where the service dies
+  # shortly after start/update or the UI dist is missing/mismatched.
+  local html js
+  html="$(curl -fsS "$base/app" 2>/dev/null || true)"
+  if [[ -z "${html//[[:space:]]/}" ]]; then
+    echo "FAIL: /app returned empty" >&2
+    echo "Next: codex-pocket restart" >&2
+    return 1
+  fi
+  js="$(
+    # BSD/macOS compatible extraction of the first Vite hashed JS bundle path.
+    # Keep this tolerant: if the grep finds nothing, we want to return "" and emit a clear FAIL below.
+    {
+      printf '%s' "$html" \
+        | tr -d '\r' \
+        | grep -oE 'src="/assets/[^"]+[.]js"' \
+        | head -n 1 \
+        | sed -E 's/^src="([^"]+)"$/\1/'
+    } || true
+  )"
+  if [[ -z "${js:-}" ]]; then
+    echo "FAIL: /app HTML missing main JS asset path" >&2
+    printf '%s\n' "${html:0:200}" >&2
+    return 1
+  fi
+  if ! curl -fsS -o /dev/null "$base$js" 2>/dev/null; then
+    echo "FAIL: main JS asset not reachable: $js" >&2
+    echo "Next: codex-pocket restart" >&2
+    return 1
+  fi
+  echo "PASS: /app"
+
   # 2) validate (requires token)
   local code body
   local resp


### PR DESCRIPTION
Extends codex-pocket smoke-test to fetch /app and ensure the hashed JS bundle is reachable. This catches 'blank app' incidents where /health passes but the SPA isn't actually servable.