### PR TITLE
Surface upstream auth invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - UI: message copy now defaults to copying plain text (markdown stripped); Shift+Click copies raw markdown source.
 - UI: message actions menu (copy, copy markdown, copy quoted, copy from here) + thread header “copy last 20”.
 - UI: mobile thread list shows more of the title by allowing 2-line titles while keeping the date visible.
+- UI/Admin/CLI: detect upstream Codex app-server auth invalidation and surface a clear recovery warning.
 
 ### UX
 - UI: on mobile, the thread status legend is now available via a `?` button (iOS doesn't reliably show `title` tooltips).

--- a/bin/codex-pocket
+++ b/bin/codex-pocket
@@ -619,6 +619,25 @@ cmd_diagnose() {
     echo "health: FAILED (try: codex-pocket restart)"
   fi
 
+  local status_json
+  status_json="$(curl_auth "$base/admin/status" 2>/dev/null || true)"
+  if [[ -n "${status_json:-}" ]]; then
+    python3 - <<'PY' <<<"$status_json"
+import json,sys
+try:
+  d=json.load(sys.stdin)
+except Exception:
+  sys.exit(0)
+auth=(d.get("anchorAuth") or {})
+status=auth.get("status")
+if status=="invalid":
+  code=auth.get("code") or "unknown"
+  at=auth.get("at") or ""
+  print(f"anchor auth: INVALID ({code}) {('at '+at) if at else ''}".strip())
+  print("  hint: re-login in Codex desktop, then run: codex-pocket restart")
+PY
+  fi
+
   echo ""
   echo "${bold}Ports${reset}"
   if command -v lsof >/dev/null 2>&1; then

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -4,6 +4,7 @@ Open `/admin` in the browser.
 
 ## What it shows
 - Service status (UI dist, DB path/retention, anchor status)
+- Anchor auth status (detects when the upstream Codex app-server token is invalid)
 - Anchor log stream
 
 ## Pair iPhone

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -18,6 +18,7 @@ Binary location after install:
 
 - `codex-pocket diagnose`
   - One command bug report (versions, ports, tailscale serve status, log tails).
+  - Warns if the upstream Codex app-server auth token is invalid.
 
 ## Commands
 
@@ -37,7 +38,7 @@ Binary location after install:
   - Equivalent of `stop` + `start`, then waits for `GET /health`.
 
 - `codex-pocket status`
-  - Prints `/admin/status` JSON.
+  - Prints `/admin/status` JSON (includes anchor auth status).
 
 - `codex-pocket logs [anchor|server]`
   - Prints logs via the Admin API.

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -44,6 +44,8 @@ These are JSON objects with a `type` field.
 
 - `{ "type": "anchor.hello", "hostname": "...", "platform": "...", "ts": "..." }`
   - Announces anchor identity.
+- `{ "type": "orbit.anchor-auth", "status": "unknown"|"ok"|"invalid", "at": "...", "code": "...", "message": "..." }`
+  - Reports upstream auth status (e.g., when Codex app-server token is invalidated).
 
 ### local-orbit -> Client
 
@@ -51,6 +53,7 @@ These are JSON objects with a `type` field.
 - `{ "type": "orbit.anchors", "anchors": [ ... ] }`
 - `{ "type": "orbit.anchor-connected", "anchor": { ... } }`
 - `{ "type": "orbit.anchor-disconnected", "anchor": { ... } }`
+- `{ "type": "orbit.anchor-auth", "status": "unknown"|"ok"|"invalid", "at": "...", "code": "...", "message": "..." }`
 
 ### local-orbit -> Anchor
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -69,6 +69,22 @@ codex-pocket logs server
 codex-pocket logs anchor
 ```
 
+### Messages Won't Send / Stuck After Long Runs
+
+If the UI is responsive but new messages never start running, the upstream Codex app-server token may have been invalidated
+(often after switching the desktop app between ChatGPT login and API key).
+
+Fix:
+
+1. Re-login in the Codex desktop app (ensure the correct auth mode is active).
+2. Restart Pocket so Anchor re-spawns app-server with fresh auth:
+
+```bash
+codex-pocket restart
+```
+
+`codex-pocket diagnose` will now warn if it detects invalid upstream auth.
+
 ### Duplicate Devices Showing In Settings
 
 This can happen when orphaned anchor processes are left behind after restarts/updates.

--- a/src/lib/anchors.svelte.ts
+++ b/src/lib/anchors.svelte.ts
@@ -12,9 +12,19 @@ interface AnchorInfo {
 
 type AnchorStatus = "unknown" | "checking" | "connected" | "none";
 
+type AnchorAuthStatus = "unknown" | "ok" | "invalid";
+
+type AnchorAuthState = {
+  status: AnchorAuthStatus;
+  at?: string;
+  code?: string;
+  message?: string;
+};
+
 class AnchorsStore {
   list = $state<AnchorInfo[]>([]);
   status = $state<AnchorStatus>("unknown");
+  auth = $state<AnchorAuthState>({ status: "unknown" });
   #checkTimeout: ReturnType<typeof setTimeout> | null = null;
 
   constructor() {
@@ -55,6 +65,16 @@ class AnchorsStore {
           this.list = this.list.filter((a) => a.id !== anchorId);
         }
         this.status = this.list.length ? "connected" : "none";
+      } else if (msg.type === "orbit.anchor-auth") {
+        const status = (msg.status as AnchorAuthStatus) || "unknown";
+        if (status === "unknown" || status === "ok" || status === "invalid") {
+          this.auth = {
+            status,
+            at: typeof msg.at === "string" ? msg.at : this.auth.at,
+            code: typeof msg.code === "string" ? msg.code : this.auth.code,
+            message: typeof msg.message === "string" ? msg.message : this.auth.message,
+          };
+        }
       }
     });
   }

--- a/src/lib/components/AppHeader.svelte
+++ b/src/lib/components/AppHeader.svelte
@@ -38,6 +38,10 @@
     const selectedSandbox = $derived(sandboxOptions.find((s) => s.value === sandbox) || sandboxOptions[1]);
     const canReconnect = $derived(status === "error" || status === "disconnected");
     const showAnchorAlert = $derived(status === "connected" && anchors.status === "none");
+    const showAuthAlert = $derived(status === "connected" && anchors.auth.status === "invalid");
+    const authAlertText = $derived(
+        anchors.auth.code ? `Auth expired (${anchors.auth.code}) — re-login on Mac` : "Auth expired — re-login on Mac"
+    );
 
     function handleClickOutside(e: MouseEvent) {
         const target = e.target as HTMLElement;
@@ -104,6 +108,11 @@
         {#if showAnchorAlert}
             <span class="separator">·</span>
             <span class="anchor-alert">No device connected</span>
+        {/if}
+
+        {#if showAuthAlert}
+            <span class="separator">·</span>
+            <span class="anchor-alert anchor-alert--auth" title={anchors.auth.message ?? ""}>{authAlertText}</span>
         {/if}
 
         {#if sandbox && onSandboxChange}
@@ -246,6 +255,11 @@
         color: var(--cli-warning);
         font-size: var(--text-xs);
         line-height: 1.4;
+    }
+
+    .anchor-alert--auth {
+        border-color: var(--cli-error);
+        color: var(--cli-error);
     }
 
     .thread-id {

--- a/src/lib/socket.svelte.ts
+++ b/src/lib/socket.svelte.ts
@@ -138,7 +138,8 @@ class SocketStore {
           if (
             msg.type === "orbit.anchors" ||
             msg.type === "orbit.anchor-connected" ||
-            msg.type === "orbit.anchor-disconnected"
+            msg.type === "orbit.anchor-disconnected" ||
+            msg.type === "orbit.anchor-auth"
           ) {
             for (const handler of this.#protocolHandlers) {
               handler(msg);

--- a/src/routes/Admin.svelte
+++ b/src/routes/Admin.svelte
@@ -11,6 +11,7 @@
     server: { host: string; port: number };
     uiDistDir: string;
     anchor: { running: boolean; cwd: string; host: string; port: number; log: string };
+    anchorAuth?: { status: "unknown" | "ok" | "invalid"; at?: string; code?: string; message?: string };
     db: { path: string; retentionDays: number; uploadDir?: string; uploadRetentionDays?: number };
     version?: { appCommit?: string };
   };
@@ -417,6 +418,24 @@
             <div class="k">Anchor log</div>
             <div class="v"><code>{status.anchor.log}</code></div>
 
+            <div class="k">Anchor auth</div>
+            <div class="v">
+              {#if status.anchorAuth?.status === "invalid"}
+                <span class="auth-bad">invalid</span>
+                {#if status.anchorAuth.code} <span class="dim">({status.anchorAuth.code})</span>{/if}
+                {#if status.anchorAuth.at} <span class="dim">at {status.anchorAuth.at}</span>{/if}
+                {#if status.anchorAuth.message}
+                  <div class="dim">{status.anchorAuth.message}</div>
+                {/if}
+                <div class="hint hint-error">Re-login in Codex desktop, then run `codex-pocket restart`.</div>
+              {:else if status.anchorAuth?.status === "ok"}
+                <span class="auth-ok">ok</span>
+                {#if status.anchorAuth.at} <span class="dim">since {status.anchorAuth.at}</span>{/if}
+              {:else}
+                <span class="dim">unknown</span>
+              {/if}
+            </div>
+
             <div class="k">DB</div>
             <div class="v"><code>{status.db.path}</code> (retention {status.db.retentionDays}d)</div>
 
@@ -644,6 +663,16 @@
   .hint-ok {
     border-color: #2c8a5a;
     color: #9be3bf;
+  }
+
+  .auth-bad {
+    color: var(--cli-error);
+    font-weight: 600;
+  }
+
+  .auth-ok {
+    color: #2c8a5a;
+    font-weight: 600;
   }
 
   .checks {


### PR DESCRIPTION
## What\n- detect Codex app-server auth invalidation in Anchor and propagate status to local-orbit\n- surface auth status in /admin/status, UI header banner, and Admin page\n- warn in `codex-pocket diagnose` when auth is invalid\n- document protocol + troubleshooting updates\n\n## Why\nWhen the desktop app auth changes (e.g., switching to API key), the app-server token can be invalidated. Pocket still looks healthy but new messages never start. We now provide a clear, actionable signal.\n\n## How to test\n- `bun run build`\n- `~/.codex-pocket/bin/codex-pocket self-test`\n- Force invalid auth (switch desktop auth) and verify:\n  - UI banner shows "Auth expired — re-login on Mac"\n  - /admin shows "Anchor auth: invalid"\n  - `codex-pocket diagnose` warns\n\n## Risk\nLow. Adds a new orbit control message and status field; no behavior changes to the relay path.\n\n## Rollback\nRevert commit 9c3eb89.