### PR TITLE
Fix admin CLI 500 on success

### DIFF
--- a/services/local-orbit/src/index.ts
+++ b/services/local-orbit/src/index.ts
@@ -373,13 +373,13 @@ async function runCliCommand(cmd: CliCommand): Promise<{
       new Response(proc.stdout).arrayBuffer(),
       new Response(proc.stderr).arrayBuffer(),
     ]);
+    const exitCode = await proc.exited.catch(() => null);
     clearTimeout(timeout);
     const out = `${Buffer.from(outBuf).toString()}\n${Buffer.from(errBuf).toString()}`.trim();
     const limited = out.length > CLI_OUTPUT_LIMIT ? out.slice(0, CLI_OUTPUT_LIMIT) + "\n…(truncated)" : out;
-    const exitCode = proc.exitCode ?? null;
     return {
-      ok: exitCode === 0,
-      exitCode,
+      ok: !timedOut && exitCode === 0,
+      exitCode: typeof exitCode === "number" ? exitCode : null,
       timedOut,
       output: limited,
       command,


### PR DESCRIPTION
## What\n- ensure CLI runner waits for process exit before returning status\n- avoid false 500 when command succeeds\n\n## Why\nAdmin CLI was reporting failure even when output showed success (exit code not yet populated).\n\n## How to test\n- Open /admin and run Status: should show success without "command failed (500)"\n\n## Risk\nLow. Waits on process exit and preserves timeout handling.\n\n## Rollback\nRevert commit 912db82.