### PR TITLE
CI: harden /admin/repair smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,58 @@ jobs:
           print('admin/validate ok')
           PY
 
+      - name: Smoke test admin repair (safe actions)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          curl -fsS \
+            -H "Authorization: Bearer ci-token" \
+            -H "Content-Type: application/json" \
+            -X POST \
+            -d '{"actions":["ensureUploadDir","pruneUploads"]}' \
+            "http://127.0.0.1:8790/admin/repair" > /tmp/admin-repair-safe.json
+
+          python3 - <<'PY'
+          import json
+          d=json.load(open('/tmp/admin-repair-safe.json'))
+          assert isinstance(d, dict), d
+          assert isinstance(d.get('ok'), bool), d
+          assert isinstance(d.get('applied'), list), d
+          assert isinstance(d.get('errors'), list), d
+          assert isinstance(d.get('checks'), list), d
+          assert not d['errors'], d
+          assert 'ensureUploadDir' in d['applied'], d
+          assert 'pruneUploads' in d['applied'], d
+          print('admin/repair safe actions ok')
+          PY
+
+      - name: Smoke test admin repair (non-Tailscale env)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          curl -fsS \
+            -H "Authorization: Bearer ci-token" \
+            -H "Content-Type: application/json" \
+            -X POST \
+            -d '{"actions":["fixTailscaleServe"]}' \
+            "http://127.0.0.1:8790/admin/repair" > /tmp/admin-repair-tailscale.json
+
+          python3 - <<'PY'
+          import json
+          d=json.load(open('/tmp/admin-repair-tailscale.json'))
+          assert isinstance(d, dict), d
+          assert isinstance(d.get('ok'), bool), d
+          assert isinstance(d.get('applied'), list), d
+          assert isinstance(d.get('errors'), list), d
+          assert isinstance(d.get('checks'), list), d
+          # In CI we typically don't have tailscale; allow either outcome as long as behavior is explicit.
+          if 'fixTailscaleServe' not in d['applied']:
+            assert len(d['errors']) >= 1, d
+          print('admin/repair non-tailscale behavior ok')
+          PY
+
       - name: Verify cache headers
         shell: bash
         run: |

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -16,6 +16,7 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 - CLI: stop/start now kill stale listeners using configured ports (not hard-coded 8790).
 - Added GitHub Actions CI workflow to build and smoke-test local-orbit on every push/PR.
 - CI now smoke-tests the WebSocket relay path (client ↔ anchor).
+- CI now smoke-tests `/admin/repair` safe actions and non-Tailscale `fixTailscaleServe` behavior.
 - `codex-pocket update` now always prints a final `summary` block and exits non-zero if post-update `ensure`/`smoke-test` fail.
 - Fixed `ensure`/`smoke-test` validation parsing to avoid false failures.
 - CLI now validates `config.json` early (avoids Python stack traces when config is missing/empty/corrupt).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 ### CI
 - Added GitHub Actions workflow to build the UI and run a local-orbit smoke test (health, admin status, cache headers, events endpoint).
 - CI now also smoke-tests the WebSocket relay path (client ↔ anchor) to catch blank-thread regressions.
+- CI now smoke-tests `/admin/repair` safe actions and non-Tailscale `fixTailscaleServe` behavior to harden self-heal path coverage across environments.
 
 ## 2026-02-08
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -14,6 +14,8 @@ The workflow is defined in:
 - Verifies:
   - `GET /health` returns OK
   - `GET /admin/validate` returns sane JSON (auth required)
+  - `POST /admin/repair` with safe actions (`ensureUploadDir`, `pruneUploads`) returns sane JSON and no errors
+  - `POST /admin/repair` with `fixTailscaleServe` behaves deterministically in non-Tailscale CI environments (explicit apply or explicit error)
   - WebSocket relay path works (client ↔ anchor protocol surface, simulated)
   - `GET /admin/status` returns sane JSON (auth required)
   - Cache headers:


### PR DESCRIPTION
## What
- add CI smoke test for `POST /admin/repair` safe actions (`ensureUploadDir`, `pruneUploads`)
- add CI smoke test for `POST /admin/repair` with `fixTailscaleServe` to verify deterministic behavior in non-Tailscale CI environments
- update CI docs, changelog, and backlog mirror

## Why
- closes issue #29 by covering the self-heal repair path in CI across environments that may not have Tailscale available
- ensures repair endpoint behavior is explicit (applied or actionable error) rather than implicit/flaky

## How To Test
1. `bun run build`
2. `bun scripts/ci/regression-guards.ts`
3. `~/.codex-pocket/bin/codex-pocket self-test`
4. `~/.codex-pocket/bin/codex-pocket smoke-test`

## Risk
- low
- CI workflow checks only; runtime behavior unchanged
- minor risk of CI flakiness mitigated by allowing explicit success-or-error path for `fixTailscaleServe`

## Rollback
- revert commit `593a695`
- or remove the two `/admin/repair` CI steps from `.github/workflows/ci.yml`

Closes #29
