### PR TITLE
Test: harden stale-listener update-flow regression

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -21,6 +21,7 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 - Fixed `ensure`/`smoke-test` validation parsing to avoid false failures.
 - CLI now validates `config.json` early (avoids Python stack traces when config is missing/empty/corrupt).
 - Added a local update-flow regression script: `scripts/test-update-flow.sh`.
+- Update-flow regression script now validates stale-listener cleanup behavior on configured ports (with default-port guard when available).
 
 - `index.html` is now served with `Cache-Control: no-store` to reduce cached broken bundle issues.
 - UI now shows build metadata (commit/time) and server shows app commit in /health + /admin/status.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - `codex-pocket update` now always prints a final `summary` and exits non-zero if `ensure` or `smoke-test` fail (next: `codex-pocket diagnose`).
 - Config parsing is now validated early to avoid Python stack traces when config.json is empty/corrupt.
 - Added a local update-flow regression script: `scripts/test-update-flow.sh`.
+- Update-flow regression script now simulates a stale Pocket-owned listener on the configured port and asserts cleanup behavior (plus a default-port guard when available) to catch hardcoded-port regressions.
 - Fixed `ensure`/`smoke-test` validation parsing so `/admin/validate` results are read correctly (no more false "empty response" failures).
 - Installer now writes `~/.codex-pocket/bin/codex-pocket` as a small wrapper that delegates to `~/.codex-pocket/app/bin/codex-pocket` to avoid stale CLI copies after updates.
 

--- a/scripts/test-update-flow.sh
+++ b/scripts/test-update-flow.sh
@@ -41,10 +41,20 @@ APORT="$(alloc_port)"
 if [[ "$APORT" == "$PORT" ]]; then
   APORT=$((PORT + 1))
 fi
+DEFAULT_GUARD_PORT=8790
 TOKEN="test-token-$(date +%s)"
+OWNED_STALE_PID=""
+DEFAULT_GUARD_PID=""
 
 cleanup() {
   if command -v lsof >/dev/null 2>&1; then
+    if [[ -n "${OWNED_STALE_PID:-}" ]]; then
+      kill "$OWNED_STALE_PID" 2>/dev/null || true
+    fi
+    if [[ -n "${DEFAULT_GUARD_PID:-}" ]]; then
+      kill "$DEFAULT_GUARD_PID" 2>/dev/null || true
+    fi
+
     local pids
     pids="$(lsof -nP -t -iTCP:"$PORT" -sTCP:LISTEN 2>/dev/null || true)"
     if [[ -n "${pids:-}" ]]; then
@@ -132,12 +142,80 @@ JSON
 
 echo "Running update in isolated test home: $APP_HOME"
 
+wait_listen() {
+  local port="$1"
+  local i
+  for i in $(seq 1 40); do
+    if lsof -nP -t -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
+pid_listening_on() {
+  local port="$1"
+  lsof -nP -t -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | head -n 1 || true
+}
+
+start_default_guard_listener() {
+  # Optional guard: when available, ensure update logic does not kill listeners on the default
+  # 8790 unless that port is actually configured.
+  if lsof -nP -t -iTCP:"$DEFAULT_GUARD_PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+    echo "Note: skipping default-port guard listener; $DEFAULT_GUARD_PORT already in use."
+    return 0
+  fi
+  (
+    cd "$TMP"
+    python3 -m http.server "$DEFAULT_GUARD_PORT" >/dev/null 2>&1 &
+    echo $! > "$TMP/default-guard.pid"
+  )
+  DEFAULT_GUARD_PID="$(cat "$TMP/default-guard.pid")"
+  wait_listen "$DEFAULT_GUARD_PORT"
+}
+
+start_owned_stale_listener() {
+  # Simulate a stale Pocket-owned process holding the configured local-orbit port.
+  (
+    cd "$APP_HOME/app"
+    python3 -m http.server "$PORT" >/dev/null 2>&1 &
+    echo $! > "$TMP/owned-stale.pid"
+  )
+  OWNED_STALE_PID="$(cat "$TMP/owned-stale.pid")"
+  wait_listen "$PORT"
+}
+
+if command -v lsof >/dev/null 2>&1; then
+  start_default_guard_listener
+  start_owned_stale_listener
+else
+  echo "Note: lsof missing; skipping stale-listener simulation checks."
+fi
+
 env \
   HOME="$FAKE_HOME" \
   CODEX_POCKET_HOME="$APP_HOME" \
   PATH="$PATH" \
   TMPDIR="$TMPDIR" \
   "$APP_HOME/bin/codex-pocket" update
+
+# Verify the stale owned listener is gone (update stop/start cleanup should remove it).
+if command -v lsof >/dev/null 2>&1; then
+  if [[ -n "${OWNED_STALE_PID:-}" ]] && ps -p "$OWNED_STALE_PID" >/dev/null 2>&1; then
+    current_pid="$(pid_listening_on "$PORT")"
+    if [[ -n "${current_pid:-}" && "$current_pid" == "$OWNED_STALE_PID" ]]; then
+      echo "FAIL: stale owned listener survived update on configured port $PORT" >&2
+      exit 1
+    fi
+  fi
+
+  # If we could allocate the default-port guard, it must survive update because configured port is not 8790.
+  if [[ -n "${DEFAULT_GUARD_PID:-}" ]] && ! ps -p "$DEFAULT_GUARD_PID" >/dev/null 2>&1; then
+    echo "FAIL: default-port guard listener on $DEFAULT_GUARD_PORT was killed unexpectedly" >&2
+    exit 1
+  fi
+fi
 
 # Validate service comes up.
 curl -fsS "http://127.0.0.1:$PORT/health" >/dev/null


### PR DESCRIPTION
## What
- strengthen `scripts/test-update-flow.sh` to simulate a stale Pocket-owned listener on the configured service port
- add an optional default-port guard listener (`8790`) and assert it is not killed unexpectedly
- add explicit post-update assertions for stale-listener cleanup behavior
- update backlog/changelog notes for this regression coverage improvement

## Why
- closes issue #31 by explicitly verifying configured-port cleanup behavior and protecting against hardcoded-port regressions in update/restart logic

## How To Test
1. `scripts/test-update-flow.sh`
2. `~/.codex-pocket/bin/codex-pocket self-test`
3. `~/.codex-pocket/bin/codex-pocket smoke-test`

## Risk
- low
- test-script hardening only; no runtime CLI behavior changes
- script remains robust when `lsof` is missing (checks are skipped with note)

## Rollback
- revert commit `d1f0d7b`
- or restore prior `scripts/test-update-flow.sh` behavior

Closes #31
