### PR TITLE
UI: add shared Admin/Settings surface primitives

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -35,6 +35,7 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 - UI: thread list now includes quick export/share actions (md + json) without opening the thread.
 - UI: message actions menu (copy, copy markdown, copy quoted, copy from here) + thread-level “copy last 20”.
 - UI: fixed a thread list instability regression caused by subscription bookkeeping inside an effect (could manifest as empty/unstable thread list).
+- Admin/settings redesign phase 1: shared surface primitives (`SectionCard`, `StatusChip`, `DangerZone`) added and `/settings` migrated to use them.
 
 ## P0 (Stability)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - UI: on mobile, the thread status legend is now available via a `?` button (iOS doesn't reliably show `title` tooltips).
 - UX: thread list ordering now preserves upstream activity timestamps (updatedAt/lastActivity) and uses a deterministic tie-breaker (less reorder-on-refresh).
 - Thread list is now sorted by most recent activity (Pocket-observed activity first, then upstream timestamps, then createdAt fallback).
+- Admin/Settings redesign phase 1: added shared settings-surface primitives (`SectionCard`, `StatusChip`, `DangerZone`) and migrated `/settings` to use them without behavior changes.
 
 ### CLI / Update
 - CLI: `start` now falls back to background mode if the launchd plist is missing (keeps update/restart usable even if the agent file is deleted).

--- a/src/lib/components/system/DangerZone.svelte
+++ b/src/lib/components/system/DangerZone.svelte
@@ -1,0 +1,13 @@
+<div class="danger-zone stack">
+  <slot />
+</div>
+
+<style>
+  .danger-zone {
+    --stack-gap: var(--space-sm);
+    border: 1px solid color-mix(in srgb, var(--cli-error) 40%, var(--cli-border));
+    border-radius: var(--radius-sm);
+    padding: var(--space-sm);
+    background: var(--cli-error-bg);
+  }
+</style>

--- a/src/lib/components/system/SectionCard.svelte
+++ b/src/lib/components/system/SectionCard.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+  export let title = "";
+  export let subtitle = "";
+</script>
+
+<section class="section stack">
+  <div class="section-header">
+    <div class="section-title">{title}</div>
+    {#if subtitle}
+      <div class="section-subtitle">{subtitle}</div>
+    {/if}
+  </div>
+  <div class="section-body stack">
+    <slot />
+  </div>
+</section>
+
+<style>
+  .section {
+    --stack-gap: 0;
+    border: 1px solid var(--cli-border);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    background: var(--cli-bg);
+  }
+
+  .section-header {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: var(--space-sm) var(--space-md);
+    background: var(--cli-bg-elevated);
+    border-bottom: 1px solid var(--cli-border);
+  }
+
+  .section-title {
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--cli-text-dim);
+    font-family: var(--font-sans);
+    font-weight: 600;
+  }
+
+  .section-subtitle {
+    font-size: var(--text-xs);
+    color: var(--cli-text-muted);
+    font-family: var(--font-sans);
+  }
+
+  .section-body {
+    --stack-gap: var(--space-md);
+    padding: var(--space-md);
+  }
+</style>

--- a/src/lib/components/system/StatusChip.svelte
+++ b/src/lib/components/system/StatusChip.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+  export let tone: "neutral" | "success" | "warning" | "error" = "neutral";
+</script>
+
+<span class="chip" data-tone={tone}><slot /></span>
+
+<style>
+  .chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: var(--text-xs);
+    line-height: 1.4;
+    border: 1px solid var(--cli-border);
+    color: var(--cli-text-dim);
+    background: var(--cli-bg-elevated);
+    font-family: var(--font-sans);
+    font-weight: 500;
+  }
+
+  .chip[data-tone="success"] {
+    border-color: color-mix(in srgb, var(--cli-success) 50%, var(--cli-border));
+    color: var(--cli-success);
+    background: color-mix(in srgb, var(--cli-success) 10%, transparent);
+  }
+
+  .chip[data-tone="warning"] {
+    border-color: color-mix(in srgb, var(--cli-warning) 50%, var(--cli-border));
+    color: var(--cli-warning);
+    background: color-mix(in srgb, var(--cli-warning) 12%, transparent);
+  }
+
+  .chip[data-tone="error"] {
+    border-color: color-mix(in srgb, var(--cli-error) 50%, var(--cli-border));
+    color: var(--cli-error);
+    background: color-mix(in srgb, var(--cli-error) 12%, transparent);
+  }
+</style>

--- a/src/routes/Settings.svelte
+++ b/src/routes/Settings.svelte
@@ -6,6 +6,9 @@
   import { socket } from "../lib/socket.svelte";
   import AppHeader from "../lib/components/AppHeader.svelte";
   import NotificationSettings from "../lib/components/NotificationSettings.svelte";
+  import SectionCard from "../lib/components/system/SectionCard.svelte";
+  import StatusChip from "../lib/components/system/StatusChip.svelte";
+  import DangerZone from "../lib/components/system/DangerZone.svelte";
 
   const ENTER_BEHAVIOR_KEY = "codex_pocket_enter_behavior";
   type EnterBehavior = "newline" | "send";
@@ -98,11 +101,7 @@
   </AppHeader>
 
   <div class="content stack">
-    <div class="section stack">
-      <div class="section-header">
-        <span class="section-title">Connection</span>
-      </div>
-      <div class="section-body stack">
+    <SectionCard title="Connection">
         <div class="field stack">
           <label for="orbit-url">orbit url</label>
           <input
@@ -118,6 +117,11 @@
             Local mode: Orbit URL is derived automatically from the site you opened.
           </p>
         {/if}
+        <div class="row">
+          <StatusChip tone={socket.status === "connected" ? "success" : socket.status === "error" ? "error" : "neutral"}>
+            {socket.status}
+          </StatusChip>
+        </div>
         <div class="connect-actions row">
           <button
             class="connect-btn"
@@ -142,14 +146,9 @@
             ? "Auto-connect paused. Click Connect to resume."
             : "Connection is automatic on app load. Disconnect to pause and to change the URL."}
         </p>
-      </div>
-    </div>
+    </SectionCard>
 
-    <div class="section stack">
-      <div class="section-header">
-        <span class="section-title">Devices</span>
-      </div>
-      <div class="section-body stack">
+    <SectionCard title="Devices">
         {#if !isSocketConnected}
           <p class="hint">
             Connect to load devices.
@@ -171,16 +170,11 @@
             {/each}
           </ul>
         {/if}
-      </div>
-    </div>
+    </SectionCard>
 
     <NotificationSettings />
 
-    <div class="section stack">
-      <div class="section-header">
-        <span class="section-title">Composer</span>
-      </div>
-      <div class="section-body stack">
+    <SectionCard title="Composer">
         <div class="field stack">
           <label for="enter-behavior">enter key</label>
           <select id="enter-behavior" bind:value={enterBehavior} onchange={(e) => setEnterBehavior((e.target as HTMLSelectElement).value as EnterBehavior)}>
@@ -189,15 +183,10 @@
           </select>
         </div>
         <p class="hint">Default is newline on all devices. This is stored per-device in your browser.</p>
-      </div>
-    </div>
+    </SectionCard>
 
     
-    <div class="section stack">
-      <div class="section-header">
-        <span class="section-title">About</span>
-      </div>
-      <div class="section-body stack">
+    <SectionCard title="About">
         <p class="hint">
           UI build: <span class="mono">{UI_COMMIT || "unknown"}</span>
           {#if UI_BUILT_AT}
@@ -207,16 +196,13 @@
         <p class="hint">
           Server: <span class="mono">{appCommit || "unknown"}</span>
         </p>
-      </div>
-    </div>
-<div class="section stack">
-      <div class="section-header">
-        <span class="section-title">Account</span>
-      </div>
-      <div class="section-body stack">
+    </SectionCard>
+
+    <SectionCard title="Account">
+      <DangerZone>
         <button class="sign-out-btn" type="button" onclick={() => auth.signOut()}>Sign out</button>
-      </div>
-    </div>
+      </DangerZone>
+    </SectionCard>
   </div>
 </div>
 
@@ -226,7 +212,7 @@
     min-height: 100vh;
     background: var(--cli-bg);
     color: var(--cli-text);
-    font-family: var(--font-mono);
+    font-family: var(--font-sans);
     font-size: var(--text-sm);
   }
 
@@ -236,31 +222,6 @@
     max-width: var(--app-max-width);
     margin: 0 auto;
     width: 100%;
-  }
-
-  .section {
-    --stack-gap: 0;
-    border: 1px solid var(--cli-border);
-    border-radius: var(--radius-md);
-    overflow: hidden;
-  }
-
-  .section-header {
-    padding: var(--space-sm) var(--space-md);
-    background: var(--cli-bg-elevated);
-    border-bottom: 1px solid var(--cli-border);
-  }
-
-  .section-title {
-    font-size: var(--text-xs);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--cli-text-dim);
-  }
-
-  .section-body {
-    --stack-gap: var(--space-md);
-    padding: var(--space-md);
   }
 
   .field {


### PR DESCRIPTION
## What
- add shared settings-surface UI primitives:
  - `src/lib/components/system/SectionCard.svelte`
  - `src/lib/components/system/StatusChip.svelte`
  - `src/lib/components/system/DangerZone.svelte`
- migrate `/settings` to use the shared card shell primitives (no behavior changes)
- add a connection status chip in settings
- place account sign-out action in a danger-zone container
- update changelog/backlog mirror

## Why
- closes issue #33 as phase 1 of the admin/settings redesign work (parent #25)
- establishes reusable components before deeper admin IA/layout changes

## How To Test
1. `bun run build`
2. `~/.codex-pocket/bin/codex-pocket self-test`
3. `~/.codex-pocket/bin/codex-pocket smoke-test`
4. Open `/settings` on desktop/mobile and verify sections render and controls behave as before

## Risk
- low to medium
- UI structure/styling refactor on settings page only
- no backend/API behavior changes

## Rollback
- revert commit `dff135a`
- or restore previous `src/routes/Settings.svelte` section wrappers

Closes #33
Refs #25
