### PR TITLE
UI: polish admin interactions and advanced disclosure

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -37,6 +37,7 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 - UI: fixed a thread list instability regression caused by subscription bookkeeping inside an effect (could manifest as empty/unstable thread list).
 - Admin/settings redesign phase 1: shared surface primitives (`SectionCard`, `StatusChip`, `DangerZone`) added and `/settings` migrated to use them.
 - Admin/settings redesign phase 2: `/admin` moved to shared card primitives and a settings-style grid hierarchy.
+- Admin/settings redesign phase 3: added admin interaction polish (confirmations, action-result chips, progressive disclosure for advanced sections).
 
 ## P0 (Stability)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - Thread list is now sorted by most recent activity (Pocket-observed activity first, then upstream timestamps, then createdAt fallback).
 - Admin/Settings redesign phase 1: added shared settings-surface primitives (`SectionCard`, `StatusChip`, `DangerZone`) and migrated `/settings` to use them without behavior changes.
 - Admin/Settings redesign phase 2: `/admin` now uses shared card primitives with a settings-style grid shell and status chips while preserving existing admin actions/flows.
+- Admin/Settings redesign phase 3: admin interactions now include disruptive-action confirmations, unified action result chips with timestamps, and progressive disclosure for advanced CLI/log/debug sections.
 
 ### CLI / Update
 - CLI: `start` now falls back to background mode if the launchd plist is missing (keeps update/restart usable even if the agent file is deleted).


### PR DESCRIPTION
## What
- add disruptive-action confirmations in `/admin` for:
  - stop anchor
  - rotate access token
  - risky remote CLI commands
- add unified action-result feedback chips with timestamps
- add progressive disclosure (`details`) wrappers for advanced sections:
  - Remote CLI
  - Anchor logs
  - Debug
- keep all existing admin endpoints and actions intact
- update changelog/backlog mirror

## Why
- closes issue #37 (phase 3 under #25) by making admin interactions safer and calmer without changing backend behavior

## How To Test
1. `bun run build`
2. `~/.codex-pocket/bin/codex-pocket self-test`
3. `~/.codex-pocket/bin/codex-pocket smoke-test`
4. In `/admin`:
   - trigger validate/repair and verify action-result chip updates
   - verify confirm dialogs appear for disruptive actions
   - expand/collapse advanced sections and verify content still works

## Risk
- medium
- UI interaction changes in admin route only; no API contract changes

## Rollback
- revert commit `9ade847`
- or restore previous admin interaction handlers/section wrappers

Closes #37
Refs #25
