### PR TITLE
ui: accessibility pass for admin/settings redesign

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -38,6 +38,7 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 - Admin/settings redesign phase 1: shared surface primitives (`SectionCard`, `StatusChip`, `DangerZone`) added and `/settings` migrated to use them.
 - Admin/settings redesign phase 2: `/admin` moved to shared card primitives and a settings-style grid hierarchy.
 - Admin/settings redesign phase 3: added admin interaction polish (confirmations, action-result chips, progressive disclosure for advanced sections).
+- Admin/settings redesign phase 4: accessibility pass for keyboard/focus visibility, semantic labels, and screen-reader action feedback on `/admin` and `/settings`.
 
 ## P0 (Stability)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - Admin/Settings redesign phase 1: added shared settings-surface primitives (`SectionCard`, `StatusChip`, `DangerZone`) and migrated `/settings` to use them without behavior changes.
 - Admin/Settings redesign phase 2: `/admin` now uses shared card primitives with a settings-style grid shell and status chips while preserving existing admin actions/flows.
 - Admin/Settings redesign phase 3: admin interactions now include disruptive-action confirmations, unified action result chips with timestamps, and progressive disclosure for advanced CLI/log/debug sections.
+- Admin/Settings redesign phase 4: accessibility pass adds stronger keyboard focus styles (including advanced disclosure summaries), explicit labels for critical controls, and screen-reader announcements for action results/errors.
 
 ### CLI / Update
 - CLI: `start` now falls back to background mode if the launchd plist is missing (keeps update/restart usable even if the agent file is deleted).

--- a/src/routes/Settings.svelte
+++ b/src/routes/Settings.svelte
@@ -94,7 +94,12 @@
 <div class="settings stack">
   <AppHeader status={socket.status}>
     {#snippet actions()}
-      <button type="button" onclick={() => theme.cycle()} title="Theme: {theme.current}">
+      <button
+        type="button"
+        onclick={() => theme.cycle()}
+        title="Theme: {theme.current}"
+        aria-label={`Cycle theme (current: ${theme.current})`}
+      >
         {themeIcons[theme.current]}
       </button>
     {/snippet}
@@ -109,14 +114,15 @@
             type="text"
             bind:value={config.url}
             placeholder="wss://orbit.example.com/ws/client"
+            aria-describedby="orbit-url-help"
             disabled={orbitLocked}
           />
         </div>
-        {#if LOCAL_MODE}
-          <p class="hint">
-            Local mode: Orbit URL is derived automatically from the site you opened.
-          </p>
-        {/if}
+        <p class="hint" id="orbit-url-help">
+          {LOCAL_MODE
+            ? "Local mode: Orbit URL is derived automatically from the site you opened."
+            : "Use your orbit websocket URL. Disconnect first to edit while connected."}
+        </p>
         <div class="row">
           <StatusChip tone={socket.status === "connected" ? "success" : socket.status === "error" ? "error" : "neutral"}>
             {socket.status}
@@ -161,7 +167,7 @@
           <ul class="anchor-list">
             {#each anchorList as anchor (anchor.id)}
               <li class="anchor-item">
-                <span class="anchor-status" title="Connected">●</span>
+                <span class="anchor-status" title="Connected" aria-hidden="true">●</span>
                 <div class="anchor-info">
                   <span class="anchor-hostname">{anchor.hostname}</span>
                   <span class="anchor-meta">{platformLabels[anchor.platform] ?? anchor.platform} · since {formatSince(anchor.connectedAt)}</span>
@@ -177,12 +183,17 @@
     <SectionCard title="Composer">
         <div class="field stack">
           <label for="enter-behavior">enter key</label>
-          <select id="enter-behavior" bind:value={enterBehavior} onchange={(e) => setEnterBehavior((e.target as HTMLSelectElement).value as EnterBehavior)}>
+          <select
+            id="enter-behavior"
+            aria-describedby="enter-behavior-help"
+            bind:value={enterBehavior}
+            onchange={(e) => setEnterBehavior((e.target as HTMLSelectElement).value as EnterBehavior)}
+          >
             <option value="newline">Enter inserts newline (Cmd/Ctrl+Enter sends)</option>
             <option value="send">Enter sends (Shift+Enter newline)</option>
           </select>
         </div>
-        <p class="hint">Default is newline on all devices. This is stored per-device in your browser.</p>
+        <p class="hint" id="enter-behavior-help">Default is newline on all devices. This is stored per-device in your browser.</p>
     </SectionCard>
 
     
@@ -200,7 +211,7 @@
 
     <SectionCard title="Account">
       <DangerZone>
-        <button class="sign-out-btn" type="button" onclick={() => auth.signOut()}>Sign out</button>
+        <button class="sign-out-btn" type="button" onclick={() => auth.signOut()} aria-label="Sign out and clear local auth token">Sign out</button>
       </DangerZone>
     </SectionCard>
   </div>
@@ -263,6 +274,7 @@
   .field input:focus {
     outline: none;
     border-color: var(--cli-prefix-agent);
+    box-shadow: var(--shadow-focus);
   }
 
   .field input:disabled {
@@ -295,6 +307,12 @@
   .connect-btn:disabled {
     opacity: 0.6;
     cursor: not-allowed;
+  }
+
+  .connect-btn:focus-visible,
+  .sign-out-btn:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--cli-prefix-agent) 55%, var(--cli-border));
   }
 
   .anchor-list {


### PR DESCRIPTION
## Summary
Accessibility pass for the Admin/Settings redesign surfaces (issue #39, parent #25).

### What changed
- Improved keyboard focus visibility for advanced disclosure summaries and interactive controls in `/admin`.
- Added screen-reader announcements for action outcomes and alerts for error feedback.
- Added semantic labeling/description wiring for key controls (`upload retention`, orbit URL help text, enter behavior help text).
- Added explicit labels for disruptive controls (stop anchor, rotate token, sign out).
- Updated backlog/changelog entries for redesign phase 4 completion.

## Why
Phase 4 of the redesign roadmap required an accessibility pass: disclosure focus treatment, semantic labels, and accessible action feedback without changing the underlying admin/settings behavior.

## How to test
1. Open `/admin` and tab through controls.
2. Confirm `Advanced:*` disclosure summaries show a visible focus ring.
3. Trigger actions (Validate/Repair/CLI/rotate token failures) and verify feedback appears and is announced by screen readers (`role=status` / `role=alert`).
4. Open `/settings` and verify focus treatment + descriptive help linkage for Orbit URL and Enter behavior controls.
5. Confirm existing flows still work (pairing, logs, debug refresh, upload retention save).

## Validation run
- `~/.codex-pocket/bin/codex-pocket self-test` ✅
- `VITE_ZANE_LOCAL=1 bunx --bun vite build` ✅

## Risk assessment
- Low risk. Changes are UI-semantic and styling focused; no backend or API contract changes.
- Primary risk is visual/focus styling regressions in edge browsers.

## Rollback
- Revert commit `30deb59`.
- Restart service/UI if needed and re-run self-test.

Closes #39
