### PR TITLE
docs: add repo sync policy and contributing guide

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -39,6 +39,7 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 - Admin/settings redesign phase 2: `/admin` moved to shared card primitives and a settings-style grid hierarchy.
 - Admin/settings redesign phase 3: added admin interaction polish (confirmations, action-result chips, progressive disclosure for advanced sections).
 - Admin/settings redesign phase 4: accessibility pass for keyboard/focus visibility, semantic labels, and screen-reader action feedback on `/admin` and `/settings`.
+- Repo hygiene: added `CONTRIBUTING.md` and documented ff-only sync policy + pre-release clean-tree check (`scripts/ci/check-clean-tree.sh`).
 
 ## P0 (Stability)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - UI/Admin/CLI: detect upstream Codex app-server auth invalidation and surface a clear recovery warning.
 - Admin: add a limited remote CLI runner for safe `codex-pocket` commands (with output capture).
 - Docs/UX: added `docs/ADMIN_REDESIGN_PROPOSAL.md` and aligned backlog/project planning for phased Admin + Settings UI redesign work.
+- Docs/Repo: added `CONTRIBUTING.md` with an explicit ff-only sync policy, PR/testing expectations, and a local pre-release clean-tree check script (`scripts/ci/check-clean-tree.sh`).
 
 ### UX
 - UI: on mobile, the thread status legend is now available via a `?` button (iOS doesn't reliably show `title` tooltips).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing
+
+Thanks for contributing to Codex Pocket.
+
+## Branching + Sync Policy
+
+- Never commit directly to `main`.
+- Create topic branches as `codex/<short-desc>`.
+- Keep `main` synced from remote and avoid local drift:
+
+```bash
+git fetch origin --prune
+git checkout main
+git pull --ff-only origin main
+```
+
+- Rebase your topic branch on latest `origin/main` before opening/updating a PR:
+
+```bash
+git fetch origin --prune
+git rebase origin/main
+```
+
+Recommended local git defaults:
+
+```bash
+git config --global pull.ff only
+git config --global fetch.prune true
+```
+
+## Pull Request Expectations
+
+- Keep scope tight (one theme per PR).
+- Tie the PR to a GitHub issue.
+- Update docs when behavior changes.
+- Update `CHANGELOG.md` for user-visible changes.
+
+PR description should include:
+- what/why
+- how to test
+- risk assessment
+- rollback instructions
+
+## Validation Before PR
+
+- Required baseline:
+
+```bash
+~/.codex-pocket/bin/codex-pocket self-test
+```
+
+- If UI is touched:
+
+```bash
+VITE_ZANE_LOCAL=1 bunx --bun vite build
+```
+
+## Pre-Release / Tagging Guard
+
+Before a release/tag operation, verify no local uncommitted changes:
+
+```bash
+./scripts/ci/check-clean-tree.sh
+```
+
+This prevents creating release artifacts from a dirty working tree.

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ If anything doesn’t work, run:
 - CI: [`docs/CI.md`](docs/CI.md)
 - Differences from Zane: [`docs/DIFFERENCES_FROM_ZANE.md`](docs/DIFFERENCES_FROM_ZANE.md)
 - Development: [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)
+- Contributing: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 
 ### Backlog (Canonical)
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -37,3 +37,12 @@ an effect created a feedback loop and made the thread list appear empty/unusable
 - Private repos: GitHub provides a monthly free tier of minutes/storage (limits vary by plan).
 
 If the repo stays public, you generally don’t need to think about cost.
+
+## Release Hygiene Note
+
+CI checkouts are always clean, so dirty-tree protection is most useful on local maintainer machines.
+Before creating tags/releases locally, run:
+
+```bash
+./scripts/ci/check-clean-tree.sh
+```

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -36,6 +36,29 @@ Output goes to `dist/`.
 Agent artifacts are local-only. Do not commit agent prompts, notes, or rule sets.
 Ignored by default: `.agents/`, `AGENT*.md`, `agent*.md`, `.agent/`, `prompts/`, `notes/`.
 
+## Git Sync Policy
+
+Keep `main` aligned with remote and avoid merge commits from `git pull`:
+
+```bash
+git fetch origin --prune
+git checkout main
+git pull --ff-only origin main
+```
+
+Recommended local defaults:
+
+```bash
+git config --global pull.ff only
+git config --global fetch.prune true
+```
+
+Before tagging/releasing from your machine, verify a clean tree:
+
+```bash
+./scripts/ci/check-clean-tree.sh
+```
+
 ## Run Local-Orbit (server)
 
 Local-Orbit requires an access token.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "bunx --bun vite",
     "build": "VITE_ZANE_LOCAL=1 VITE_CODEX_POCKET_COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo unknown) VITE_CODEX_POCKET_BUILT_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ) bunx --bun vite build",
     "preview": "bunx --bun vite preview --port 4173",
+    "check:clean-tree": "./scripts/ci/check-clean-tree.sh",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/scripts/ci/check-clean-tree.sh
+++ b/scripts/ci/check-clean-tree.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "Not inside a git repository."
+  exit 1
+fi
+
+if [[ -n "$(git status --porcelain --untracked-files=normal)" ]]; then
+  echo "Working tree is not clean."
+  echo "Commit/stash/discard local changes before release/tag operations."
+  exit 1
+fi
+
+echo "Working tree is clean."


### PR DESCRIPTION
## Summary
Implements issue #19 by formalizing repository sync policy and contributor workflow docs, and adding a local release hygiene guard.

### What changed
- Added `CONTRIBUTING.md` with:
  - ff-only sync policy for `main`
  - branch/rebase/PR expectations
  - required validation commands
  - pre-release clean-tree guard step
- Added `scripts/ci/check-clean-tree.sh` and wired it as `bun run check:clean-tree`.
- Linked contributing guide from `README.md`.
- Added matching guidance to `docs/DEVELOPMENT.md` and `docs/CI.md`.
- Updated `BACKLOG.md` and `CHANGELOG.md`.

## Why
We hit divergent-branch pull errors. This establishes a single, explicit sync policy (`pull --ff-only`) and gives maintainers a reliable local check to prevent release/tag actions from dirty trees.

## How to test
1. Read `CONTRIBUTING.md` and confirm commands/workflow are complete and consistent with repo policy.
2. Run `bun run check:clean-tree` in a dirty tree (should fail).
3. Run `~/.codex-pocket/bin/codex-pocket self-test`.

## Validation run
- `bun run check:clean-tree` (expected failure in dirty tree) ✅
- `~/.codex-pocket/bin/codex-pocket self-test` ✅

## Risk assessment
- Low risk. Documentation + helper script only; no runtime server/UI behavior changes.

## Rollback
- Revert commit `3b37eed`.

Closes #19
