### PR TITLE
ux: add customizable composer quick-reply shortcuts

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -40,6 +40,7 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 - Admin/settings redesign phase 3: added admin interaction polish (confirmations, action-result chips, progressive disclosure for advanced sections).
 - Admin/settings redesign phase 4: accessibility pass for keyboard/focus visibility, semantic labels, and screen-reader action feedback on `/admin` and `/settings`.
 - Repo hygiene: added `CONTRIBUTING.md` and documented ff-only sync policy + pre-release clean-tree check (`scripts/ci/check-clean-tree.sh`).
+- Composer quick-reply shortcuts: added one-tap presets in thread composer, with customizable label/text presets in `/settings` (persisted per-device).
 
 ## P0 (Stability)
 
@@ -53,9 +54,6 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 - Thread activity indicator (idle/working/blocked) polish:
   - Ensure it is visible on mobile.
   - Add a legend or tooltip.
-- Composer quick-reply shortcuts:
-  - Add one-tap preset replies (for example: "Proceed", "Elaborate").
-  - Allow users to customize the shortcut labels/text in settings.
 - Settings UI redesign:
   - Rework `/settings` into a clearer, more modern layout with stronger visual hierarchy.
   - Align styling/components with the Admin refresh so both surfaces feel consistent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - Admin: add a limited remote CLI runner for safe `codex-pocket` commands (with output capture).
 - Docs/UX: added `docs/ADMIN_REDESIGN_PROPOSAL.md` and aligned backlog/project planning for phased Admin + Settings UI redesign work.
 - Docs/Repo: added `CONTRIBUTING.md` with an explicit ff-only sync policy, PR/testing expectations, and a local pre-release clean-tree check script (`scripts/ci/check-clean-tree.sh`).
+- UX: added one-tap composer quick-reply shortcuts (default `Proceed`/`Elaborate`) plus a `/settings` editor to customize and persist preset labels/text per device.
 
 ### UX
 - UI: on mobile, the thread status legend is now available via a `?` button (iOS doesn't reliably show `title` tooltips).

--- a/src/lib/quickReplies.ts
+++ b/src/lib/quickReplies.ts
@@ -1,0 +1,50 @@
+export type QuickReply = {
+  label: string;
+  text: string;
+};
+
+export const QUICK_REPLIES_STORAGE_KEY = "codex_pocket_quick_replies_v1";
+export const MAX_QUICK_REPLIES = 5;
+
+export const DEFAULT_QUICK_REPLIES: QuickReply[] = [
+  { label: "Proceed", text: "Proceed." },
+  { label: "Elaborate", text: "Please elaborate." },
+];
+
+export function normalizeQuickReplies(raw: unknown): QuickReply[] {
+  if (!Array.isArray(raw)) return DEFAULT_QUICK_REPLIES;
+  const next: QuickReply[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const label = typeof (item as Record<string, unknown>).label === "string"
+      ? (item as Record<string, string>).label.trim()
+      : "";
+    const text = typeof (item as Record<string, unknown>).text === "string"
+      ? (item as Record<string, string>).text.trim()
+      : "";
+    if (!label || !text) continue;
+    next.push({ label: label.slice(0, 24), text: text.slice(0, 280) });
+    if (next.length >= MAX_QUICK_REPLIES) break;
+  }
+  return next.length ? next : DEFAULT_QUICK_REPLIES;
+}
+
+export function loadQuickReplies(): QuickReply[] {
+  try {
+    const raw = localStorage.getItem(QUICK_REPLIES_STORAGE_KEY);
+    if (!raw) return DEFAULT_QUICK_REPLIES;
+    return normalizeQuickReplies(JSON.parse(raw));
+  } catch {
+    return DEFAULT_QUICK_REPLIES;
+  }
+}
+
+export function saveQuickReplies(items: QuickReply[]): QuickReply[] {
+  const next = normalizeQuickReplies(items);
+  try {
+    localStorage.setItem(QUICK_REPLIES_STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // ignore localStorage failures
+  }
+  return next;
+}


### PR DESCRIPTION
## Summary
Implements issue #42 by adding one-tap quick reply shortcuts in the thread composer and a settings editor to customize/persist presets per device.

### What changed
- Added shared quick-reply persistence helper:
  - `src/lib/quickReplies.ts`
  - default presets: `Proceed`, `Elaborate`
  - localStorage load/save + normalization/limits
- Added composer quick-reply UI:
  - `src/lib/components/PromptInput.svelte`
  - renders one-tap preset buttons and sends selected text without typing
- Added settings customization UI:
  - `src/routes/Settings.svelte`
  - edit label/text, add/remove presets, save presets
- Updated docs tracking:
  - `BACKLOG.md`
  - `CHANGELOG.md`

## Why
Users frequently send repeated iterative prompts. Quick-reply presets reduce repetitive typing, especially on mobile.

## How to test
1. Open a thread composer and verify quick-reply buttons appear (`Proceed`, `Elaborate`).
2. Tap a quick reply and verify it sends immediately.
3. Open `/settings` → `Quick Replies`, edit/add/remove presets, click `Save presets`.
4. Return to a thread and verify composer shows updated presets.
5. Confirm standard composer behavior remains unchanged (Enter/newline and normal send).

## Validation run
- `VITE_ZANE_LOCAL=1 bunx --bun vite build` ✅
- `~/.codex-pocket/bin/codex-pocket self-test` ✅

## Risk assessment
- Low to medium. UI-only changes touching composer/settings behavior; no backend API changes.
- Main risk is unintended composer UX friction if presets are misconfigured.

## Rollback
- Revert commit `73da3a1`.

Closes #42
