### PR TITLE
security: rate-limit pairing and upload token endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,10 @@ jobs:
           export ZANE_LOCAL_AUTOSTART_ANCHOR='0'
           export ZANE_LOCAL_UPLOAD_DIR='/tmp/codex-pocket-ci-uploads'
           export ZANE_LOCAL_UPLOAD_RETENTION_DAYS='0'
+          export ZANE_LOCAL_PAIR_RATE_LIMIT_MAX='2'
+          export ZANE_LOCAL_PAIR_RATE_LIMIT_WINDOW_SEC='120'
+          export ZANE_LOCAL_UPLOAD_NEW_RATE_LIMIT_MAX='2'
+          export ZANE_LOCAL_UPLOAD_NEW_RATE_LIMIT_WINDOW_SEC='120'
 
           mkdir -p "$ZANE_LOCAL_UPLOAD_DIR"
 
@@ -171,6 +175,45 @@ jobs:
             assert len(d['errors']) >= 1, d
           print('admin/repair non-tailscale behavior ok')
           PY
+
+      - name: Smoke test sensitive endpoint rate limits
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # /admin/pair/new: first two requests should pass, third should be rate-limited.
+          for i in 1 2; do
+            curl -fsS \
+              -H "Authorization: Bearer ci-token" \
+              -H "Content-Type: application/json" \
+              -X POST \
+              -d '{}' \
+              "http://127.0.0.1:8790/admin/pair/new" >/tmp/pair-${i}.json
+          done
+          pair_status=$(curl -sS -o /tmp/pair-3.json -w '%{http_code}' \
+            -H "Authorization: Bearer ci-token" \
+            -H "Content-Type: application/json" \
+            -X POST \
+            -d '{}' \
+            "http://127.0.0.1:8790/admin/pair/new")
+          test "$pair_status" = "429"
+
+          # /uploads/new: first two requests should pass, third should be rate-limited.
+          for i in 1 2; do
+            curl -fsS \
+              -H "Authorization: Bearer ci-token" \
+              -H "Content-Type: application/json" \
+              -X POST \
+              -d '{"filename":"x.png","mime":"image/png","bytes":10}' \
+              "http://127.0.0.1:8790/uploads/new" >/tmp/upload-new-${i}.json
+          done
+          upload_status=$(curl -sS -o /tmp/upload-new-3.json -w '%{http_code}' \
+            -H "Authorization: Bearer ci-token" \
+            -H "Content-Type: application/json" \
+            -X POST \
+            -d '{"filename":"x.png","mime":"image/png","bytes":10}' \
+            "http://127.0.0.1:8790/uploads/new")
+          test "$upload_status" = "429"
 
       - name: Verify cache headers
         shell: bash

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -43,6 +43,7 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 - Composer quick-reply shortcuts: added one-tap presets in thread composer, with customizable label/text presets in `/settings` (persisted per-device).
 - Settings redesign follow-up: `/settings` now uses a responsive card grid hierarchy (desktop 2-column, mobile 1-column) with core controls prioritized.
 - Thread export/share polish: added `.html` export in thread view + thread-list quick actions (Markdown/JSON retained).
+- Security hardening: added rate limits for sensitive token-minting endpoints (`/admin/pair/new`, `/uploads/new`) with explicit `429` behavior and CI coverage.
 
 ## P0 (Stability)
 
@@ -72,7 +73,6 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 
 - Per-device tokens (instead of one global bearer token) and revocation UI.
 - Optional read-only mode for paired devices.
-- Rate limit sensitive endpoints (`/admin/pair/new`, `/uploads/new`).
 
 ## P4 (Platform)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - UX: added one-tap composer quick-reply shortcuts (default `Proceed`/`Elaborate`) plus a `/settings` editor to customize and persist preset labels/text per device.
 - Settings redesign follow-up: `/settings` now uses a responsive two-column card grid on desktop (single-column mobile) with core controls prioritized above secondary account/about details.
 - Thread export/share: added `.html` export format in thread view and thread-list quick actions (alongside existing Markdown/JSON exports).
+- Security: added in-process rate limits for sensitive token-minting endpoints (`/admin/pair/new`, `/uploads/new`) with explicit `429` responses and CI smoke coverage.
 
 ### UX
 - UI: on mobile, the thread status legend is now available via a `?` button (iOS doesn't reliably show `title` tooltips).

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -16,6 +16,7 @@ The workflow is defined in:
   - `GET /admin/validate` returns sane JSON (auth required)
   - `POST /admin/repair` with safe actions (`ensureUploadDir`, `pruneUploads`) returns sane JSON and no errors
   - `POST /admin/repair` with `fixTailscaleServe` behaves deterministically in non-Tailscale CI environments (explicit apply or explicit error)
+  - Sensitive endpoint rate limits return explicit `429` once CI's low threshold is exceeded (`/admin/pair/new`, `/uploads/new`)
   - WebSocket relay path works (client ↔ anchor protocol surface, simulated)
   - `GET /admin/status` returns sane JSON (auth required)
   - Cache headers:


### PR DESCRIPTION
## Summary
Implements issue #48 by adding in-process rate limiting for sensitive token-minting endpoints and adding CI coverage for 429 behavior.

### What changed
- Added rate limiting primitives in `services/local-orbit/src/index.ts`.
- Applied limits to:
  - `POST /admin/pair/new`
  - `POST /uploads/new`
- Added explicit `429` JSON responses with `retry-after` header when limits are exceeded.
- Added deterministic CI smoke step that verifies:
  - first requests pass
  - third request receives `429` for both endpoints under low CI-only thresholds
- Updated `docs/CI.md`, `BACKLOG.md`, and `CHANGELOG.md`.

## Why
These endpoints create sensitive capabilities (pairing/upload tokens). Basic throttling reduces abuse risk with minimal operational complexity.

## How to test
1. Start local-orbit with small limiter env vars (`*_RATE_LIMIT_MAX=2`, `*_RATE_LIMIT_WINDOW_SEC=120`).
2. Call `/admin/pair/new` three times with valid auth; verify third response is `429`.
3. Call `/uploads/new` three times with valid auth; verify third response is `429`.
4. Confirm normal flows still work under non-exceeded usage.

## Validation run
- `~/.codex-pocket/bin/codex-pocket self-test` ✅
- `VITE_ZANE_LOCAL=1 bunx --bun vite build` ✅

## Risk assessment
- Low to medium. Server-side behavior change for two endpoints only.
- Main risk is overly strict limits; defaults are conservative and configurable via env.

## Rollback
- Revert commit `0075dd6`.

Closes #48
