### PR TITLE
ux: add attachment chips and multi-image composer upload

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -44,6 +44,7 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 - Settings redesign follow-up: `/settings` now uses a responsive card grid hierarchy (desktop 2-column, mobile 1-column) with core controls prioritized.
 - Thread export/share polish: added `.html` export in thread view + thread-list quick actions (Markdown/JSON retained).
 - Security hardening: added rate limits for sensitive token-minting endpoints (`/admin/pair/new`, `/uploads/new`) with explicit `429` behavior and CI coverage.
+- Attachment UX polish: composer now uses removable attachment chips and supports multiple image attachments per message without requiring manual markdown edits.
 
 ## P0 (Stability)
 
@@ -63,8 +64,7 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 ## P2 (Attachments)
 
 - Attachment UI polish:
-  - Optional “attachment chip” UI so users don’t have to see markdown inserted into the composer.
-  - Multiple attachments per message.
+  - Preview thumbnails for selected image chips (optional).
 - Upload retention:
   - Scheduled pruning + reporting in Admin.
   - Better visibility: size used, oldest/newest, last prune time.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - Settings redesign follow-up: `/settings` now uses a responsive two-column card grid on desktop (single-column mobile) with core controls prioritized above secondary account/about details.
 - Thread export/share: added `.html` export format in thread view and thread-list quick actions (alongside existing Markdown/JSON exports).
 - Security: added in-process rate limits for sensitive token-minting endpoints (`/admin/pair/new`, `/uploads/new`) with explicit `429` responses and CI smoke coverage.
+- Attachments: composer now supports multi-image selection and shows removable attachment chips; image markdown is generated automatically on send so users no longer need to edit attachment markdown manually.
 
 ### UX
 - UI: on mobile, the thread status legend is now available via a `?` button (iOS doesn't reliably show `title` tooltips).

--- a/src/lib/components/PromptInput.svelte
+++ b/src/lib/components/PromptInput.svelte
@@ -63,7 +63,7 @@
     quickReplies = loadQuickReplies();
   });
 
-  const canSubmit = $derived(input.trim().length > 0 && !disabled);
+  const canSubmit = $derived((input.trim().length > 0 || pendingAttachments.length > 0) && !disabled);
 	  let uploadBusy = $state(false);
 	  let uploadError = $state<string | null>(null);
 	  let pendingAttachments = $state<ImageAttachment[]>([]);
@@ -82,10 +82,22 @@
     reasoningOptions.find((r) => r.value === reasoningEffort)?.label || "Medium"
   );
 
+	  function composeInputWithAttachments(baseText: string): string {
+    if (pendingAttachments.length === 0) return baseText.trim();
+    const attachmentMarkdown = pendingAttachments
+      .map((a) => {
+        const alt = (a.filename || "image").replace(/[\r\n\t\u0000]/g, " ").trim();
+        return `![${alt}](${a.viewUrl})`;
+      })
+      .join("\n");
+    const text = baseText.trim();
+    return text ? `${text}\n${attachmentMarkdown}` : attachmentMarkdown;
+  }
+
 	  function handleSubmit(e: Event) {
 	    e.preventDefault();
 	    if (!canSubmit) return;
-	    onSubmit(input.trim(), pendingAttachments);
+	    onSubmit(composeInputWithAttachments(input), pendingAttachments);
 	    input = "";
 	    pendingAttachments = [];
 	  }
@@ -121,63 +133,75 @@
   function sendQuickReply(text: string) {
     if (disabled) return;
     const trimmed = text.trim();
-    if (!trimmed) return;
-    onSubmit(trimmed, pendingAttachments);
+    if (!trimmed && pendingAttachments.length === 0) return;
+    onSubmit(composeInputWithAttachments(trimmed), pendingAttachments);
     input = "";
     pendingAttachments = [];
   }
 
+  function removeAttachment(index: number) {
+    pendingAttachments = pendingAttachments.filter((_, i) => i !== index);
+  }
+
 	  async function handlePickImage(e: Event) {
     const el = e.target as HTMLInputElement;
-    const file = el.files?.[0];
+    const files = Array.from(el.files ?? []);
     el.value = "";
-    if (!file) return;
+    if (!files.length) return;
 
 	    uploadError = null;
 	    uploadBusy = true;
-	    try {
-	      const meta = await api.post<{
-	        token: string;
-	        uploadUrl: string;
-	        viewUrl: string;
-	        localPath: string;
-	        filename: string;
-	        mime: string;
-	      }>("/uploads/new", {
-	        filename: file.name,
-	        mime: file.type || "application/octet-stream",
-	        bytes: file.size,
-	      });
+    const uploaded: ImageAttachment[] = [];
+    let failed = 0;
+    let lastError = "";
+    try {
+      for (const file of files) {
+        try {
+          const meta = await api.post<{
+            token: string;
+            uploadUrl: string;
+            viewUrl: string;
+            localPath: string;
+            filename: string;
+            mime: string;
+          }>("/uploads/new", {
+            filename: file.name,
+            mime: file.type || "application/octet-stream",
+            bytes: file.size,
+          });
 
-      const buf = await file.arrayBuffer();
-      const putPath = `/uploads/${encodeURIComponent(meta.token)}`;
-      const res = await api.putRaw(putPath, buf, file.type || "application/octet-stream");
-      if (!res.ok) {
-        const t = await res.text().catch(() => "");
-        throw new Error(t || `upload failed (${res.status})`);
+          const buf = await file.arrayBuffer();
+          const putPath = `/uploads/${encodeURIComponent(meta.token)}`;
+          const res = await api.putRaw(putPath, buf, file.type || "application/octet-stream");
+          if (!res.ok) {
+            const t = await res.text().catch(() => "");
+            throw new Error(t || `upload failed (${res.status})`);
+          }
+
+          const fallbackName = (file.name || "image").replace(/[\r\n\t\u0000]/g, " ").trim();
+          uploaded.push({
+            kind: "image",
+            filename: meta.filename || file.name || fallbackName || "image",
+            mime: meta.mime || file.type || "application/octet-stream",
+            localPath: meta.localPath,
+            viewUrl: meta.viewUrl,
+          });
+        } catch (err) {
+          failed += 1;
+          lastError = err instanceof Error ? err.message : "Upload failed";
+        }
       }
-
-	      // Insert as markdown so it renders inline in the chat UI.
-	      const alt = (file.name || "image").replace(/[\r\n\t\u0000]/g, " ").trim();
-	      const md = `![${alt}](${meta.viewUrl})`;
-	      input = `${input}${input ? "\n" : ""}${md}`;
-
-	      // Also keep a structured attachment so we can pass pixels to Codex app-server.
-	      pendingAttachments = [
-	        ...pendingAttachments,
-	        {
-	          kind: "image",
-	          filename: meta.filename || file.name || alt || "image",
-	          mime: meta.mime || file.type || "application/octet-stream",
-	          localPath: meta.localPath,
-	          viewUrl: meta.viewUrl,
-	        },
-	      ];
-	    } catch (err) {
-	      uploadError = err instanceof Error ? err.message : "Upload failed";
-	    } finally {
-	      uploadBusy = false;
-	    }
+      if (uploaded.length) {
+        pendingAttachments = [...pendingAttachments, ...uploaded];
+      }
+      if (failed) {
+        uploadError = uploaded.length
+          ? `Uploaded ${uploaded.length}/${files.length} image(s). ${lastError}`
+          : lastError || "Upload failed";
+      }
+    } finally {
+      uploadBusy = false;
+    }
 	  }
 </script>
 
@@ -200,13 +224,31 @@
         {/each}
       </div>
     {/if}
-    <textarea
+	    <textarea
       bind:value={input}
       onkeydown={handleKeydown}
       placeholder="What would you like to do?"
       rows="1"
       {disabled}
-    ></textarea>
+	    ></textarea>
+    {#if pendingAttachments.length}
+      <div class="attachment-chips" role="list" aria-label="Selected attachments">
+        {#each pendingAttachments as item, i (`${item.localPath}:${item.filename}:${i}`)}
+          <div class="attachment-chip" role="listitem">
+            <span class="attachment-name">{item.filename}</span>
+            <button
+              type="button"
+              class="attachment-remove"
+              onclick={() => removeAttachment(i)}
+              aria-label={`Remove attachment ${item.filename}`}
+              title="Remove attachment"
+            >
+              ×
+            </button>
+          </div>
+        {/each}
+      </div>
+    {/if}
 
     <div class="footer split">
       <div class="tools row">
@@ -216,13 +258,14 @@
 	          We want the user to be able to choose either Camera or Photo Library.
 	        -->
 	        <label class="tool-btn row" title="Attach image">
-	          <input
-	            class="file-input"
-	            type="file"
-	            accept="image/*"
-	            onchange={handlePickImage}
-	            disabled={disabled || uploadBusy}
-	          />
+		          <input
+		            class="file-input"
+		            type="file"
+		            accept="image/*"
+                multiple
+		            onchange={handlePickImage}
+		            disabled={disabled || uploadBusy}
+		          />
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <path d="M21 15V8a2 2 0 0 0-2-2h-3l-2-2H10L8 6H5a2 2 0 0 0-2 2v7" />
             <path d="M3 15l4-4 4 4 4-4 6 6" />
@@ -457,6 +500,48 @@
   textarea:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+  }
+
+  .attachment-chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+    padding: 0 var(--space-md) var(--space-sm) var(--space-md);
+  }
+
+  .attachment-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    border: 1px solid var(--cli-border);
+    background: var(--cli-bg-elevated);
+    color: var(--cli-text-dim);
+    font-size: var(--text-xs);
+    font-family: var(--font-sans);
+    max-width: 100%;
+  }
+
+  .attachment-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 260px;
+  }
+
+  .attachment-remove {
+    border: none;
+    background: transparent;
+    color: var(--cli-text-muted);
+    cursor: pointer;
+    font-size: var(--text-sm);
+    line-height: 1;
+    padding: 0;
+  }
+
+  .attachment-remove:hover {
+    color: var(--cli-error);
   }
 
   .footer {


### PR DESCRIPTION
## Summary
Implements issue #50 by adding attachment chips in the composer and supporting multiple image attachments in one message.

### What changed
- `src/lib/components/PromptInput.svelte`:
  - file picker now supports `multiple` image selection
  - uploads each selected image and appends successful uploads to attachment list
  - added removable attachment chips before composer footer
  - removed markdown insertion during selection; markdown is now generated automatically at submit-time
  - submit is enabled when either text or attachments are present
- Updated `BACKLOG.md` and `CHANGELOG.md`.

## Why
Users should not need to edit attachment markdown manually, and attaching multiple images should be one-step.

## How to test
1. Open a thread, attach multiple images in one selection.
2. Verify chips appear and individual chips can be removed.
3. Send with text + attachments and attachments-only.
4. Verify images render in transcript as before.
5. Verify plain text-only sends still work.

## Validation run
- `VITE_ZANE_LOCAL=1 bunx --bun vite build` ✅
- `~/.codex-pocket/bin/codex-pocket self-test` ✅

## Risk assessment
- Medium-low. UI/composer behavior change only; backend API unchanged.
- Main risk is partial upload handling UX; failures are surfaced with clear error text.

## Rollback
- Revert commit `1f048d7`.

Closes #50
