### PR TITLE
admin: add upload footprint stats and prune visibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,26 @@ jobs:
           print('admin/status ok')
           PY
 
+      - name: Smoke test admin uploads stats
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          curl -fsS \
+            -H "Authorization: Bearer ci-token" \
+            "http://127.0.0.1:8790/admin/uploads/stats" > /tmp/admin-uploads-stats.json
+
+          python3 - <<'PY'
+          import json
+          d=json.load(open('/tmp/admin-uploads-stats.json'))
+          assert isinstance(d.get('fileCount'), int), d
+          assert isinstance(d.get('totalBytes'), int), d
+          assert 'oldestAt' in d, d
+          assert 'newestAt' in d, d
+          assert 'lastPruneAt' in d, d
+          print('admin/uploads/stats ok')
+          PY
+
       - name: Smoke test admin validate
         shell: bash
         run: |

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -45,6 +45,7 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 - Thread export/share polish: added `.html` export in thread view + thread-list quick actions (Markdown/JSON retained).
 - Security hardening: added rate limits for sensitive token-minting endpoints (`/admin/pair/new`, `/uploads/new`) with explicit `429` behavior and CI coverage.
 - Attachment UX polish: composer now uses removable attachment chips and supports multiple image attachments per message without requiring manual markdown edits.
+- Upload retention visibility: `/admin` now shows upload footprint stats (size, file count, oldest/newest, and last prune activity).
 
 ## P0 (Stability)
 
@@ -67,7 +68,6 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
   - Preview thumbnails for selected image chips (optional).
 - Upload retention:
   - Scheduled pruning + reporting in Admin.
-  - Better visibility: size used, oldest/newest, last prune time.
 
 ## P3 (Security / Admin)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - Thread export/share: added `.html` export format in thread view and thread-list quick actions (alongside existing Markdown/JSON exports).
 - Security: added in-process rate limits for sensitive token-minting endpoints (`/admin/pair/new`, `/uploads/new`) with explicit `429` responses and CI smoke coverage.
 - Attachments: composer now supports multi-image selection and shows removable attachment chips; image markdown is generated automatically on send so users no longer need to edit attachment markdown manually.
+- Admin uploads: added storage visibility in `/admin` (file count, bytes used, oldest/newest timestamps, and last prune activity) backed by a new authenticated `/admin/uploads/stats` endpoint.
 
 ### UX
 - UI: on mobile, the thread status legend is now available via a `?` button (iOS doesn't reliably show `title` tooltips).

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -14,6 +14,7 @@ The workflow is defined in:
 - Verifies:
   - `GET /health` returns OK
   - `GET /admin/validate` returns sane JSON (auth required)
+  - `GET /admin/uploads/stats` returns upload footprint stats (auth required)
   - `POST /admin/repair` with safe actions (`ensureUploadDir`, `pruneUploads`) returns sane JSON and no errors
   - `POST /admin/repair` with `fixTailscaleServe` behaves deterministically in non-Tailscale CI environments (explicit apply or explicit error)
   - Sensitive endpoint rate limits return explicit `429` once CI's low threshold is exceeded (`/admin/pair/new`, `/uploads/new`)


### PR DESCRIPTION
## Summary
Implements issue #52 by adding upload footprint stats endpoint + Admin UI visibility for upload storage and prune recency.

### What changed
- `services/local-orbit/src/index.ts`
  - Added `getUploadStats()` helper (file count, total bytes, oldest/newest file times, last prune activity time).
  - Added authenticated `GET /admin/uploads/stats` endpoint.
- `src/routes/Admin.svelte`
  - Added upload stats fetch + display in Uploads card.
  - Shows: stored files, storage used, oldest/newest file timestamps, last prune activity.
- `.github/workflows/ci.yml`
  - Added smoke check for `/admin/uploads/stats` response shape.
- Updated `docs/CI.md`, `BACKLOG.md`, `CHANGELOG.md`.

## Why
Retention settings existed, but operators lacked quick visibility into actual storage footprint and cleanup recency.

## How to test
1. Open `/admin` and verify Uploads section shows footprint stats.
2. Trigger `Run cleanup now` and confirm stats refresh.
3. Verify retention save path still works.
4. Confirm endpoint returns JSON with expected keys:
   - `fileCount`, `totalBytes`, `oldestAt`, `newestAt`, `lastPruneAt`

## Validation run
- `~/.codex-pocket/bin/codex-pocket self-test` ✅
- `VITE_ZANE_LOCAL=1 bunx --bun vite build` ✅

## Risk assessment
- Low to medium. Adds one read-only admin endpoint and UI read path; existing retention/prune behavior unchanged.

## Rollback
- Revert commit `9384899`.

Closes #52
