### PR TITLE
ux: add print-to-pdf thread export actions

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -46,6 +46,7 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 - Security hardening: added rate limits for sensitive token-minting endpoints (`/admin/pair/new`, `/uploads/new`) with explicit `429` behavior and CI coverage.
 - Attachment UX polish: composer now uses removable attachment chips and supports multiple image attachments per message without requiring manual markdown edits.
 - Upload retention visibility: `/admin` now shows upload footprint stats (size, file count, oldest/newest, and last prune activity).
+- Thread export/share polish: added PDF export action (print-to-PDF) in thread view + thread-list quick actions.
 
 ## P0 (Stability)
 
@@ -59,8 +60,6 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 - Thread activity indicator (idle/working/blocked) polish:
   - Ensure it is visible on mobile.
   - Add a legend or tooltip.
-- Thread export/share polish:
-  - Add “Export as PDF” (optional).
 
 ## P2 (Attachments)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - Security: added in-process rate limits for sensitive token-minting endpoints (`/admin/pair/new`, `/uploads/new`) with explicit `429` responses and CI smoke coverage.
 - Attachments: composer now supports multi-image selection and shows removable attachment chips; image markdown is generated automatically on send so users no longer need to edit attachment markdown manually.
 - Admin uploads: added storage visibility in `/admin` (file count, bytes used, oldest/newest timestamps, and last prune activity) backed by a new authenticated `/admin/uploads/stats` endpoint.
+- Thread export/share: added PDF export action (print-to-PDF via browser print dialog) in thread view and thread-list quick actions, using existing HTML export content.
 
 ### UX
 - UI: on mobile, the thread status legend is now available via a `?` button (iOS doesn't reliably show `title` tooltips).

--- a/src/routes/Thread.svelte
+++ b/src/routes/Thread.svelte
@@ -306,6 +306,23 @@
         downloadThreadHtml();
     }
 
+    function printThreadPdf() {
+        const html = threadToHtml();
+        if (!html) return;
+        const printDoc = html.replace(
+            "</body>",
+            "<script>window.addEventListener('load', () => { setTimeout(() => { window.focus(); window.print(); }, 80); });<\\/script></body>"
+        );
+        const w = window.open("", "_blank");
+        if (!w) {
+            downloadThreadHtml();
+            return;
+        }
+        w.document.open();
+        w.document.write(printDoc);
+        w.document.close();
+    }
+
     function downloadThread() {
         const id = threadId;
         if (!id) return;
@@ -643,6 +660,17 @@
                             title="Download thread as .html"
                         >
                             export html
+                        </button>
+                        <button
+                            type="button"
+                            role="menuitem"
+                            onclick={() => {
+                                closeMoreMenu();
+                                printThreadPdf();
+                            }}
+                            title="Print / save as PDF"
+                        >
+                            export pdf
                         </button>
                         <button
                             type="button"


### PR DESCRIPTION
## Summary
Implements issue #54 by adding a PDF export action via browser print-to-PDF using existing HTML export content.

### What changed
- `src/routes/Thread.svelte`
  - Added `export pdf` menu action in thread view.
  - Uses `threadToHtml()` and opens print dialog (fallback to HTML download if popup blocked).
- `src/routes/Home.svelte`
  - Added `pdf` export quick action in thread list.
  - Extended export flow with `pdf` mode using the same print path.
- Updated `BACKLOG.md` and `CHANGELOG.md`.

## Why
Provides a practical PDF export flow with zero new heavy dependencies by reusing the existing HTML export renderer.

## How to test
1. In thread view, open More menu and run `export pdf`.
2. In thread list, click the new `PDF` export quick action.
3. Verify print dialog opens and can save to PDF.
4. Confirm md/json/html exports remain unchanged.

## Validation run
- `~/.codex-pocket/bin/codex-pocket self-test` ✅
- `VITE_ZANE_LOCAL=1 bunx --bun vite build` ✅

## Risk assessment
- Low. UI-only export action additions.
- Main risk is popup blockers; fallback to HTML download is included.

## Rollback
- Revert commit `559fcf8`.

Closes #54
