### PR TITLE
docs: prune stale completed P1 backlog items

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -47,19 +47,13 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 - Attachment UX polish: composer now uses removable attachment chips and supports multiple image attachments per message without requiring manual markdown edits.
 - Upload retention visibility: `/admin` now shows upload footprint stats (size, file count, oldest/newest, and last prune activity).
 - Thread export/share polish: added PDF export action (print-to-PDF) in thread view + thread-list quick actions.
+- Backlog hygiene: removed stale completed P1 items (admin redesign parent + thread activity indicator polish) so active sections stay actionable.
 
 ## P0 (Stability)
 
 - Extend CI smoke coverage to include WebSocket relay and (optionally) additional admin repair paths with stubs/bypasses for non-Tailscale environments.
 
 ## P1 (UX)
-
-- Admin UI redesign (Issue #25):
-  - Implement the system-settings style overhaul described in `docs/ADMIN_REDESIGN_PROPOSAL.md`.
-  - Prioritize status clarity, progressive disclosure, and mobile usability.
-- Thread activity indicator (idle/working/blocked) polish:
-  - Ensure it is visible on mobile.
-  - Add a legend or tooltip.
 
 ## P2 (Attachments)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - Attachments: composer now supports multi-image selection and shows removable attachment chips; image markdown is generated automatically on send so users no longer need to edit attachment markdown manually.
 - Admin uploads: added storage visibility in `/admin` (file count, bytes used, oldest/newest timestamps, and last prune activity) backed by a new authenticated `/admin/uploads/stats` endpoint.
 - Thread export/share: added PDF export action (print-to-PDF via browser print dialog) in thread view and thread-list quick actions, using existing HTML export content.
+- Docs/Backlog: cleaned stale completed P1 items from active backlog sections (admin redesign parent + thread indicator polish) to keep roadmap actionable.
 
 ### UX
 - UI: on mobile, the thread status legend is now available via a `?` button (iOS doesn't reliably show `title` tooltips).


### PR DESCRIPTION
## Summary
Implements issue #56 by cleaning stale completed P1 items from active backlog sections.

### What changed
- Removed completed items from active P1 list:
  - Admin redesign parent (already completed via phased child issues/PRs)
  - Thread activity indicator polish (already shipped)
- Added a "Recently Done" note capturing this cleanup.
- Added changelog note for backlog hygiene.

## Why
The active backlog should represent actionable remaining work, not already delivered milestones.

## How to test
1. Review `BACKLOG.md` active P1/P2 sections for actionable-only items.
2. Confirm completed context remains represented in `Recently Done`.

## Validation run
- `~/.codex-pocket/bin/codex-pocket self-test` ✅

## Risk assessment
- Low. Documentation/backlog hygiene only.

## Rollback
- Revert commit `f9e5bc8`.

Closes #56
