### PR TITLE
admin: enrich upload stats with last prune detail/source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,8 @@ jobs:
           assert 'oldestAt' in d, d
           assert 'newestAt' in d, d
           assert 'lastPruneAt' in d, d
+          assert 'lastPruneMessage' in d, d
+          assert 'lastPruneSource' in d, d
           print('admin/uploads/stats ok')
           PY
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -48,6 +48,7 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 - Upload retention visibility: `/admin` now shows upload footprint stats (size, file count, oldest/newest, and last prune activity).
 - Thread export/share polish: added PDF export action (print-to-PDF) in thread view + thread-list quick actions.
 - Backlog hygiene: removed stale completed P1 items (admin redesign parent + thread activity indicator polish) so active sections stay actionable.
+- Upload retention reporting: `/admin/uploads/stats` now includes last prune detail/source (manual/scheduled/unknown), shown in Admin Uploads UI.
 
 ## P0 (Stability)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - Admin uploads: added storage visibility in `/admin` (file count, bytes used, oldest/newest timestamps, and last prune activity) backed by a new authenticated `/admin/uploads/stats` endpoint.
 - Thread export/share: added PDF export action (print-to-PDF via browser print dialog) in thread view and thread-list quick actions, using existing HTML export content.
 - Docs/Backlog: cleaned stale completed P1 items from active backlog sections (admin redesign parent + thread indicator polish) to keep roadmap actionable.
+- Admin uploads reporting: `/admin/uploads/stats` now includes last prune detail/source (manual/scheduled/unknown), surfaced in Admin Uploads UI.
 
 ### UX
 - UI: on mobile, the thread status legend is now available via a `?` button (iOS doesn't reliably show `title` tooltips).

--- a/src/routes/Admin.svelte
+++ b/src/routes/Admin.svelte
@@ -24,6 +24,8 @@
     oldestAt: string | null;
     newestAt: string | null;
     lastPruneAt: string | null;
+    lastPruneMessage: string | null;
+    lastPruneSource: "manual" | "scheduled" | "unknown" | null;
   };
 
   let status = $state<Status | null>(null);
@@ -781,6 +783,10 @@
             <div class="v">{uploadStats.newestAt ? new Date(uploadStats.newestAt).toLocaleString() : "n/a"}</div>
             <div class="k">Last prune activity</div>
             <div class="v">{uploadStats.lastPruneAt ? new Date(uploadStats.lastPruneAt).toLocaleString() : "n/a"}</div>
+            <div class="k">Last prune source</div>
+            <div class="v">{uploadStats.lastPruneSource || "n/a"}</div>
+            <div class="k">Last prune detail</div>
+            <div class="v">{uploadStats.lastPruneMessage || "n/a"}</div>
           </div>
         {/if}
 


### PR DESCRIPTION
## Summary
Implements issue #58 by enriching upload stats/reporting with prune detail and source classification.

### What changed
- `services/local-orbit/src/index.ts`
  - `/admin/uploads/stats` now includes:
    - `lastPruneMessage`
    - `lastPruneSource` (`manual` | `scheduled` | `unknown` | `null`)
- `src/routes/Admin.svelte`
  - Uploads card now displays last prune source + detail message.
- `.github/workflows/ci.yml`
  - uploads-stats smoke assertions now include new fields.
- Updated `BACKLOG.md` and `CHANGELOG.md`.

## Why
Operators need context, not just a timestamp, to understand what cleanup action most recently occurred.

## How to test
1. Open `/admin` and inspect Uploads card.
2. Trigger a manual prune and verify source/detail fields update on refresh.
3. Confirm existing stats fields still render correctly.

## Validation run
- `~/.codex-pocket/bin/codex-pocket self-test` ✅
- `VITE_ZANE_LOCAL=1 bunx --bun vite build` ✅

## Risk assessment
- Low. Additive reporting fields and UI display only.

## Rollback
- Revert commit `b4a937f`.

Closes #58
