### PR TITLE
ux: add thumbnail previews to attachment chips

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -49,6 +49,7 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 - Thread export/share polish: added PDF export action (print-to-PDF) in thread view + thread-list quick actions.
 - Backlog hygiene: removed stale completed P1 items (admin redesign parent + thread activity indicator polish) so active sections stay actionable.
 - Upload retention reporting: `/admin/uploads/stats` now includes last prune detail/source (manual/scheduled/unknown), shown in Admin Uploads UI.
+- Attachment chips now include image thumbnails in composer for faster visual confirmation before send.
 
 ## P0 (Stability)
 
@@ -59,7 +60,6 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 ## P2 (Attachments)
 
 - Attachment UI polish:
-  - Preview thumbnails for selected image chips (optional).
 - Upload retention:
   - Scheduled pruning + reporting in Admin.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - Thread export/share: added PDF export action (print-to-PDF via browser print dialog) in thread view and thread-list quick actions, using existing HTML export content.
 - Docs/Backlog: cleaned stale completed P1 items from active backlog sections (admin redesign parent + thread indicator polish) to keep roadmap actionable.
 - Admin uploads reporting: `/admin/uploads/stats` now includes last prune detail/source (manual/scheduled/unknown), surfaced in Admin Uploads UI.
+- Attachments: composer attachment chips now render small image thumbnails for faster visual verification before sending.
 
 ### UX
 - UI: on mobile, the thread status legend is now available via a `?` button (iOS doesn't reliably show `title` tooltips).

--- a/src/lib/components/PromptInput.svelte
+++ b/src/lib/components/PromptInput.svelte
@@ -235,6 +235,7 @@
       <div class="attachment-chips" role="list" aria-label="Selected attachments">
         {#each pendingAttachments as item, i (`${item.localPath}:${item.filename}:${i}`)}
           <div class="attachment-chip" role="listitem">
+            <img class="attachment-thumb" src={item.viewUrl} alt={item.filename} loading="lazy" />
             <span class="attachment-name">{item.filename}</span>
             <button
               type="button"
@@ -521,6 +522,16 @@
     font-size: var(--text-xs);
     font-family: var(--font-sans);
     max-width: 100%;
+  }
+
+  .attachment-thumb {
+    width: 20px;
+    height: 20px;
+    border-radius: 4px;
+    object-fit: cover;
+    border: 1px solid var(--cli-border);
+    background: var(--cli-bg);
+    flex: 0 0 auto;
   }
 
   .attachment-name {


### PR DESCRIPTION
## Summary
Implements issue #60 by adding thumbnail previews to composer attachment chips.

### What changed
- `src/lib/components/PromptInput.svelte`
  - attachment chips now render a small thumbnail from `viewUrl`
  - existing remove action and multi-attachment behavior preserved
- Updated `BACKLOG.md` and `CHANGELOG.md`.

## Why
Thumbnail previews let users visually confirm selected images before sending.

## How to test
1. Attach one or more images in a thread composer.
2. Confirm each attachment chip shows a thumbnail + filename.
3. Remove one chip and confirm the correct attachment is removed.
4. Send message and confirm existing attachment behavior remains unchanged.

## Validation run
- `VITE_ZANE_LOCAL=1 bunx --bun vite build` ✅
- `~/.codex-pocket/bin/codex-pocket self-test` ✅

## Risk assessment
- Low. UI-only enhancement to existing chip component.

## Rollback
- Revert commit `3fa5031`.

Closes #60
