### PR TITLE
Admin/Settings redesign pass: calmer system-console UI polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - Docs/Repo: added `CONTRIBUTING.md` with an explicit ff-only sync policy, PR/testing expectations, and a local pre-release clean-tree check script (`scripts/ci/check-clean-tree.sh`).
 - UX: added one-tap composer quick-reply shortcuts (default `Proceed`/`Elaborate`) plus a `/settings` editor to customize and persist preset labels/text per device.
 - Settings redesign follow-up: `/settings` now uses a responsive two-column card grid on desktop (single-column mobile) with core controls prioritized above secondary account/about details.
+- Admin/Settings redesign pass: refreshed `/admin` and `/settings` visual surfaces with calmer system-console styling (improved card hierarchy, spacing, button/input treatments, and responsive two-column admin operations layout) with no behavioral/API changes.
 - Thread export/share: added `.html` export format in thread view and thread-list quick actions (alongside existing Markdown/JSON exports).
 - Security: added in-process rate limits for sensitive token-minting endpoints (`/admin/pair/new`, `/uploads/new`) with explicit `429` responses and CI smoke coverage.
 - Attachments: composer now supports multi-image selection and shows removable attachment chips; image markdown is generated automatically on send so users no longer need to edit attachment markdown manually.

--- a/src/routes/Admin.svelte
+++ b/src/routes/Admin.svelte
@@ -562,7 +562,8 @@
   </AppHeader>
 
   <div class="content stack">
-    <SectionCard title="Admin" subtitle="System status and core operations">
+    <div class="panel panel-main">
+      <SectionCard title="Admin" subtitle="System status and core operations">
         {#if statusError}
           <p class="hint hint-error" role="alert">{statusError}</p>
         {/if}
@@ -681,9 +682,10 @@
           </div>
         {/if}
         {/if}
-    </SectionCard>
+      </SectionCard>
+    </div>
 
-    <details class="advanced" bind:open={showCliAdvanced}>
+    <details class="advanced panel panel-side" bind:open={showCliAdvanced}>
       <summary id="advanced-cli-summary">Advanced: Remote CLI</summary>
       <div role="region" aria-labelledby="advanced-cli-summary">
       <SectionCard title="CLI (Remote)" subtitle="Run a limited set of safe codex-pocket commands">
@@ -732,7 +734,8 @@
       </div>
     </details>
 
-    <SectionCard title="Pair iPhone" subtitle="Generate a short-lived code and scan on iPhone">
+    <div class="panel panel-side">
+      <SectionCard title="Pair iPhone" subtitle="Generate a short-lived code and scan on iPhone">
         <p class="hint">Generate a short-lived pairing code, then scan the QR with your iPhone.</p>
         {#if pairError}
           <p class="hint hint-error" role="alert">{pairError}</p>
@@ -758,9 +761,10 @@
             <p class="hint hint-error">QR did not render. Open the Link above on your iPhone.</p>
           {/if}
         {/if}
-    </SectionCard>
+      </SectionCard>
+    </div>
 
-    <details class="advanced" bind:open={showLogsAdvanced}>
+    <details class="advanced panel panel-main" bind:open={showLogsAdvanced}>
       <summary id="advanced-logs-summary">Advanced: Logs</summary>
       <div role="region" aria-labelledby="advanced-logs-summary">
       <SectionCard title="Anchor Logs (Tail)">
@@ -769,7 +773,8 @@
       </div>
     </details>
 
-    <SectionCard title="Uploads">
+    <div class="panel panel-main">
+      <SectionCard title="Uploads">
         <p class="hint">Uploads are stored locally on your Mac. Default retention is permanent.</p>
         {#if uploadStats}
           <div class="kv">
@@ -815,9 +820,10 @@
         <div class="row buttons">
         </div>
         <pre class="logs">{opsLog || "(no ops logs yet)"}</pre>
-    </SectionCard>
+      </SectionCard>
+    </div>
 
-    <details class="advanced" bind:open={showDebugAdvanced}>
+    <details class="advanced panel panel-side" bind:open={showDebugAdvanced}>
       <summary id="advanced-debug-summary">Advanced: Debug</summary>
       <div role="region" aria-labelledby="advanced-debug-summary">
       <SectionCard title="Debug">
@@ -853,55 +859,149 @@
 <style>
   .admin {
     min-height: 100vh;
+    background:
+      radial-gradient(1200px 520px at 8% -18%, color-mix(in srgb, var(--cli-prefix-agent) 14%, transparent), transparent 70%),
+      radial-gradient(800px 420px at 92% -30%, color-mix(in srgb, var(--cli-prefix-web) 11%, transparent), transparent 74%),
+      var(--cli-bg);
   }
+
   .content {
-    padding: var(--space-md);
-    max-width: var(--app-max-width);
+    padding: var(--space-lg) var(--space-md) var(--space-xl);
+    max-width: 1240px;
     margin: 0 auto;
     width: 100%;
     display: grid;
-    gap: var(--space-md);
+    gap: var(--space-lg);
     grid-template-columns: 1fr;
   }
 
-  @media (min-width: 980px) {
+  @media (min-width: 1040px) {
     .content {
-      grid-template-columns: 1.3fr 1fr;
+      grid-template-columns: minmax(0, 1.45fr) minmax(0, 1fr);
       align-items: start;
     }
+
+    .panel-main {
+      grid-column: 1;
+    }
+
+    .panel-side {
+      grid-column: 2;
+    }
+  }
+
+  .panel {
+    min-width: 0;
+  }
+
+  .admin :global(.section) {
+    border-radius: 12px;
+    border-color: color-mix(in srgb, var(--cli-border) 85%, transparent);
+    background: color-mix(in srgb, var(--cli-bg-elevated) 84%, var(--cli-bg));
+    box-shadow: 0 16px 34px -30px rgba(0, 0, 0, 0.9);
+  }
+
+  .admin :global(.section-header) {
+    padding: var(--space-md) var(--space-md) var(--space-sm);
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--cli-bg-elevated) 75%, var(--cli-bg)),
+      color-mix(in srgb, var(--cli-bg) 88%, transparent)
+    );
+  }
+
+  .admin :global(.section-title) {
+    font-size: 0.69rem;
+    letter-spacing: 0.11em;
+  }
+
+  .admin :global(.section-body) {
+    --stack-gap: var(--space-md);
+    padding: var(--space-md);
   }
 
   .kv {
     display: grid;
-    grid-template-columns: 160px 1fr;
+    grid-template-columns: minmax(140px, 178px) 1fr;
     gap: var(--space-sm) var(--space-md);
     font-family: var(--font-mono);
-    font-size: 13px;
+    font-size: 0.79rem;
+    line-height: 1.5;
   }
+
   .k {
-    opacity: 0.7;
+    color: var(--cli-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    font-size: 0.65rem;
+    padding-top: 3px;
   }
+
+  .v {
+    min-width: 0;
+    color: var(--cli-text);
+  }
+
   .v code {
     word-break: break-all;
+    padding: 0.08rem 0.35rem;
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--cli-bg-hover) 65%, transparent);
   }
+
   .buttons {
     gap: var(--space-sm);
     flex-wrap: wrap;
-    margin-top: var(--space-md);
+    margin-top: var(--space-sm);
+  }
+
+  button,
+  .admin a[href]:not(.brand) {
+    border-radius: 7px;
+  }
+
+  button {
+    padding: 0.45rem 0.72rem;
+    border: 1px solid color-mix(in srgb, var(--cli-border) 86%, transparent);
+    background: color-mix(in srgb, var(--cli-bg-elevated) 85%, transparent);
+    color: var(--cli-text);
+    font-family: var(--font-mono);
+    font-size: 0.74rem;
+    letter-spacing: 0.01em;
+    cursor: pointer;
+  }
+
+  button:hover:enabled {
+    border-color: color-mix(in srgb, var(--cli-prefix-agent) 38%, var(--cli-border));
+    background: color-mix(in srgb, var(--cli-bg-hover) 60%, var(--cli-bg-elevated));
+  }
+
+  button:disabled {
+    opacity: 0.56;
+    cursor: not-allowed;
+  }
+
+  button.primary {
+    border-color: color-mix(in srgb, var(--cli-prefix-agent) 46%, var(--cli-border));
+    background: color-mix(in srgb, var(--cli-prefix-agent) 20%, var(--cli-bg-elevated));
   }
 
   .advanced {
-    border: 1px solid var(--cli-border);
-    border-radius: var(--radius-sm);
-    background: var(--cli-bg);
+    border: 1px solid color-mix(in srgb, var(--cli-border) 86%, transparent);
+    border-radius: 12px;
+    overflow: hidden;
+    background: color-mix(in srgb, var(--cli-bg-elevated) 84%, var(--cli-bg));
+    box-shadow: 0 14px 30px -28px rgba(0, 0, 0, 0.85);
   }
 
   .advanced > summary {
     cursor: pointer;
-    padding: var(--space-sm) var(--space-md);
-    font-family: var(--font-sans);
-    font-size: var(--text-xs);
-    color: var(--cli-text-dim);
+    padding: 0.78rem var(--space-md);
+    font-family: var(--font-mono);
+    font-size: 0.71rem;
+    color: var(--cli-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.09em;
     list-style: none;
     border-bottom: 1px solid transparent;
   }
@@ -914,7 +1014,7 @@
 
   .advanced[open] > summary {
     border-bottom-color: var(--cli-border);
-    background: var(--cli-bg-elevated);
+    background: color-mix(in srgb, var(--cli-bg-hover) 45%, var(--cli-bg-elevated));
   }
 
   button:focus-visible,
@@ -938,31 +1038,35 @@
     height: 260px;
     image-rendering: pixelated;
     border: 1px solid var(--cli-border);
-    border-radius: var(--radius-sm);
+    border-radius: 10px;
     background: #fff;
-    padding: 6px;
+    padding: 8px;
   }
+
   .danger {
-    background: #5d1b1b;
-    border: 1px solid #a33;
-    color: #fff;
+    border-color: color-mix(in srgb, var(--cli-error) 55%, var(--cli-border));
+    color: color-mix(in srgb, var(--cli-error) 75%, var(--cli-text));
+    background: color-mix(in srgb, var(--cli-error) 18%, var(--cli-bg-elevated));
   }
+
   .logs {
     max-height: 400px;
     overflow: auto;
-    background: rgba(0, 0, 0, 0.35);
+    background: color-mix(in srgb, var(--cli-bg) 84%, #000 16%);
     padding: var(--space-md);
     border-radius: 10px;
-    border: 1px solid rgba(255, 255, 255, 0.08);
+    border: 1px solid color-mix(in srgb, var(--cli-border) 82%, transparent);
+    line-height: 1.45;
+    font-size: 0.76rem;
   }
 
   .field input {
     width: 100%;
     padding: var(--space-sm);
-    background: var(--cli-bg);
+    background: color-mix(in srgb, var(--cli-bg) 72%, var(--cli-bg-elevated));
     color: var(--cli-text);
-    border: 1px solid var(--cli-border);
-    border-radius: var(--radius-sm);
+    border: 1px solid color-mix(in srgb, var(--cli-border) 86%, transparent);
+    border-radius: 8px;
     font-family: var(--font-mono);
     font-size: var(--text-sm);
   }
@@ -970,10 +1074,10 @@
   .field select {
     width: 100%;
     padding: var(--space-sm);
-    background: var(--cli-bg);
+    background: color-mix(in srgb, var(--cli-bg) 72%, var(--cli-bg-elevated));
     color: var(--cli-text);
-    border: 1px solid var(--cli-border);
-    border-radius: var(--radius-sm);
+    border: 1px solid color-mix(in srgb, var(--cli-border) 86%, transparent);
+    border-radius: 8px;
     font-family: var(--font-mono);
     font-size: var(--text-sm);
   }
@@ -998,8 +1102,7 @@
   }
 
   .hint-ok {
-    border-color: #2c8a5a;
-    color: #9be3bf;
+    color: color-mix(in srgb, var(--cli-success) 72%, var(--cli-text));
   }
 
   .auth-bad {
@@ -1008,7 +1111,7 @@
   }
 
   .auth-ok {
-    color: #2c8a5a;
+    color: var(--cli-success);
     font-weight: 600;
   }
 
@@ -1022,12 +1125,12 @@
     gap: var(--space-sm);
     align-items: baseline;
     font-family: var(--font-mono);
-    font-size: 13px;
+    font-size: 0.78rem;
   }
 
   .dot {
     font-size: 10px;
-    color: #2c8a5a;
+    color: var(--cli-success);
   }
   .dot.bad {
     color: var(--cli-error);
@@ -1036,25 +1139,47 @@
   .check-detail {
     margin: 0;
     padding: var(--space-sm);
-    background: rgba(0, 0, 0, 0.35);
-    border: 1px solid var(--cli-border);
-    border-radius: var(--radius-sm);
+    background: color-mix(in srgb, var(--cli-bg) 84%, #000 16%);
+    border: 1px solid color-mix(in srgb, var(--cli-border) 82%, transparent);
+    border-radius: 8px;
     max-height: 200px;
     overflow: auto;
-    font-size: 12px;
+    font-size: 0.75rem;
   }
 
   .cli-output {
     margin: 0;
     padding: var(--space-sm);
-    background: rgba(0, 0, 0, 0.35);
-    border: 1px solid var(--cli-border);
-    border-radius: var(--radius-sm);
+    background: color-mix(in srgb, var(--cli-bg) 84%, #000 16%);
+    border: 1px solid color-mix(in srgb, var(--cli-border) 82%, transparent);
+    border-radius: 8px;
     max-height: 260px;
     overflow: auto;
-    font-size: 12px;
+    font-size: 0.75rem;
     white-space: pre-wrap;
   }
+
+  .hint {
+    color: var(--cli-text-muted);
+    line-height: 1.55;
+  }
+
+  @media (max-width: 660px) {
+    .content {
+      padding: var(--space-md) var(--space-sm) var(--space-lg);
+      gap: var(--space-md);
+    }
+
+    .kv {
+      grid-template-columns: 1fr;
+      gap: 0.25rem;
+    }
+
+    .k {
+      padding-top: 0;
+    }
+  }
+
   .sr-only {
     position: absolute;
     width: 1px;

--- a/src/routes/Settings.svelte
+++ b/src/routes/Settings.svelte
@@ -323,23 +323,26 @@
   .settings {
     --stack-gap: 0;
     min-height: 100vh;
-    background: var(--cli-bg);
+    background:
+      radial-gradient(920px 460px at 0% -20%, color-mix(in srgb, var(--cli-prefix-agent) 12%, transparent), transparent 72%),
+      radial-gradient(780px 360px at 100% -30%, color-mix(in srgb, var(--cli-prefix-web) 10%, transparent), transparent 74%),
+      var(--cli-bg);
     color: var(--cli-text);
     font-family: var(--font-sans);
     font-size: var(--text-sm);
   }
 
   .content {
-    padding: var(--space-md);
-    max-width: var(--app-max-width);
+    padding: var(--space-lg) var(--space-md) var(--space-xl);
+    max-width: 1220px;
     margin: 0 auto;
     width: 100%;
     display: grid;
-    gap: var(--space-md);
+    gap: var(--space-lg);
     grid-template-columns: 1fr;
   }
 
-  @media (min-width: 980px) {
+  @media (min-width: 1040px) {
     .content {
       grid-template-columns: 1.35fr 1fr;
       align-items: start;
@@ -354,6 +357,27 @@
     grid-column: 1 / -1;
   }
 
+  .settings :global(.section) {
+    border-radius: 12px;
+    border-color: color-mix(in srgb, var(--cli-border) 86%, transparent);
+    background: color-mix(in srgb, var(--cli-bg-elevated) 86%, var(--cli-bg));
+    box-shadow: 0 15px 34px -30px rgba(0, 0, 0, 0.88);
+  }
+
+  .settings :global(.section-header) {
+    padding: var(--space-md) var(--space-md) var(--space-sm);
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--cli-bg-elevated) 76%, var(--cli-bg)),
+      color-mix(in srgb, var(--cli-bg) 90%, transparent)
+    );
+  }
+
+  .settings :global(.section-title) {
+    font-size: 0.69rem;
+    letter-spacing: 0.1em;
+  }
+
   .field {
     --stack-gap: var(--space-xs);
   }
@@ -366,9 +390,9 @@
 
   .field input {
     padding: var(--space-sm);
-    background: var(--cli-bg);
-    border: 1px solid var(--cli-border);
-    border-radius: var(--radius-sm);
+    background: color-mix(in srgb, var(--cli-bg) 72%, var(--cli-bg-elevated));
+    border: 1px solid color-mix(in srgb, var(--cli-border) 86%, transparent);
+    border-radius: 8px;
     color: var(--cli-text);
     font-family: var(--font-mono);
   }
@@ -376,10 +400,10 @@
   .field select {
     width: 100%;
     padding: var(--space-sm);
-    background: var(--cli-bg);
+    background: color-mix(in srgb, var(--cli-bg) 72%, var(--cli-bg-elevated));
     color: var(--cli-text);
-    border: 1px solid var(--cli-border);
-    border-radius: var(--radius-sm);
+    border: 1px solid color-mix(in srgb, var(--cli-border) 86%, transparent);
+    border-radius: 8px;
     font-family: var(--font-mono);
     font-size: var(--text-sm);
   }
@@ -407,25 +431,25 @@
   }
 
   .connect-btn {
-    padding: var(--space-xs) var(--space-sm);
-    background: transparent;
-    border: 1px solid var(--cli-border);
-    border-radius: var(--radius-sm);
+    padding: 0.45rem 0.72rem;
+    background: color-mix(in srgb, var(--cli-bg-elevated) 86%, transparent);
+    border: 1px solid color-mix(in srgb, var(--cli-border) 86%, transparent);
+    border-radius: 7px;
     color: var(--cli-text);
     font-family: var(--font-mono);
-    font-size: var(--text-xs);
+    font-size: 0.74rem;
     cursor: pointer;
     transition: all var(--transition-fast);
   }
 
   .plain-btn {
-    padding: var(--space-xs) var(--space-sm);
-    background: transparent;
-    border: 1px solid var(--cli-border);
-    border-radius: var(--radius-sm);
+    padding: 0.45rem 0.72rem;
+    background: color-mix(in srgb, var(--cli-bg-elevated) 86%, transparent);
+    border: 1px solid color-mix(in srgb, var(--cli-border) 86%, transparent);
+    border-radius: 7px;
     color: var(--cli-text-dim);
     font-family: var(--font-sans);
-    font-size: var(--text-xs);
+    font-size: 0.74rem;
     cursor: pointer;
     transition: all var(--transition-fast);
   }
@@ -436,8 +460,8 @@
   }
 
   .connect-btn:hover:enabled {
-    background: var(--cli-bg-hover);
-    border-color: var(--cli-text-muted);
+    background: color-mix(in srgb, var(--cli-bg-hover) 60%, var(--cli-bg-elevated));
+    border-color: color-mix(in srgb, var(--cli-prefix-agent) 38%, var(--cli-border));
   }
 
   .connect-btn:disabled {
@@ -512,7 +536,7 @@
   .hint {
     color: var(--cli-text-muted);
     font-size: var(--text-xs);
-    line-height: 1.5;
+    line-height: 1.55;
     margin: 0;
   }
 
@@ -526,20 +550,27 @@
 
   .sign-out-btn {
     align-self: flex-start;
-    padding: var(--space-xs) var(--space-sm);
-    background: transparent;
-    border: 1px solid var(--cli-border);
-    border-radius: var(--radius-sm);
-    color: var(--cli-error, #ef4444);
+    padding: 0.45rem 0.72rem;
+    background: color-mix(in srgb, var(--cli-error) 10%, var(--cli-bg-elevated));
+    border: 1px solid color-mix(in srgb, var(--cli-error) 55%, var(--cli-border));
+    border-radius: 7px;
+    color: color-mix(in srgb, var(--cli-error) 76%, var(--cli-text));
     font-family: var(--font-mono);
-    font-size: var(--text-xs);
+    font-size: 0.74rem;
     cursor: pointer;
     transition: all var(--transition-fast);
   }
 
   .sign-out-btn:hover {
-    background: var(--cli-error-bg);
-    border-color: var(--cli-error, #ef4444);
+    background: color-mix(in srgb, var(--cli-error) 16%, var(--cli-bg-elevated));
+    border-color: color-mix(in srgb, var(--cli-error) 68%, var(--cli-border));
+  }
+
+  @media (max-width: 660px) {
+    .content {
+      padding: var(--space-md) var(--space-sm) var(--space-lg);
+      gap: var(--space-md);
+    }
   }
   .mono { font-family: var(--font-mono); }
   .dim { color: var(--cli-text-dim); }


### PR DESCRIPTION
## What/Why
This PR delivers a focused visual overhaul for `/admin` (primary) and `/settings` (secondary) to make both pages calmer, cleaner, and easier to scan without changing behavior or endpoints.

- Restructures `/admin` into a clearer desktop ops layout (main + side panels) while preserving all existing actions.
- Improves hierarchy/legibility with refined card surfaces, typography, spacing, and consistent button/input treatments.
- Aligns `/settings` styling to the same visual system for continuity.
- Updates changelog for the user-visible redesign pass.

Closes #62

## How to test
1. Open `/admin` and verify all existing controls still work: Validate, Repair, Stop Anchor, Pairing code generation, uploads retention/save/prune, debug refresh, token rotation prompt, CLI run.
2. Confirm advanced sections still expand/collapse: Remote CLI, Logs, Debug.
3. Open `/settings` and verify connection controls, quick replies editing/saving, notifications, and sign out still behave unchanged.
4. Check responsive behavior on narrow/mobile width and desktop width.

## Validation run
- `~/.codex-pocket/bin/codex-pocket self-test` ✅
- `VITE_ZANE_LOCAL=1 bunx --bun vite build` ✅

## Risk assessment
- Low to medium: UI-only changes in Svelte route styles/markup wrappers.
- No backend/API changes, no auth/credential flow changes.
- Primary risk is layout/CSS regressions at certain viewport sizes.

## Rollback
- Revert this PR commit to restore previous admin/settings UI.
- No data or schema rollback required.
