### PR TITLE
Admin uploads: configurable auto-cleanup interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - Docs/Backlog: cleaned stale completed P1 items from active backlog sections (admin redesign parent + thread indicator polish) to keep roadmap actionable.
 - Admin uploads reporting: `/admin/uploads/stats` now includes last prune detail/source (manual/scheduled/unknown), surfaced in Admin Uploads UI.
 - Attachments: composer attachment chips now render small image thumbnails for faster visual verification before sending.
+- Admin uploads: auto-cleanup cadence is now configurable (1-168 hours) and visible in `/admin`, persisted with retention settings.
 
 ### UX
 - UI: on mobile, the thread status legend is now available via a `?` button (iOS doesn't reliably show `title` tooltips).


### PR DESCRIPTION
## What/Why
This PR completes the remaining upload-retention roadmap item by making automatic upload cleanup cadence configurable instead of fixed.

- Adds configurable upload auto-cleanup interval (`pruneIntervalHours`) with bounds (1..168 hours).
- Persists interval with upload retention settings in config JSON.
- Surfaces interval in `/admin/status`.
- Extends Admin Uploads UI to edit/save interval and display current cadence.
- Keeps manual prune behavior unchanged.

Closes #64

## How to test
1. Open `/admin` and go to Uploads.
2. Set `upload retention (days)` and `auto cleanup interval (hours)` then click Save.
3. Verify the status section shows updated values for retention + auto-cleanup cadence.
4. Run manual cleanup and verify existing behavior is unchanged.
5. Restart service and confirm the saved values persist.

## Validation run
- `~/.codex-pocket/bin/codex-pocket self-test` ✅
- `VITE_ZANE_LOCAL=1 bunx --bun vite build` ✅
- `bunx tsc --noEmit` ✅

## Risk assessment
- Low/medium: small backend config + admin UI integration change.
- No auth model changes.
- Main risk is invalid interval input handling or persistence edge cases when config file is missing.

## Rollback
- Revert this PR commit.
- Existing retention behavior falls back to prior fixed interval logic.
