### PR TITLE
CI: smoke-test admin upload settings updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,40 @@ jobs:
           print('admin/uploads/stats ok')
           PY
 
+      - name: Smoke test admin upload settings update
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          curl -fsS \
+            -H "Authorization: Bearer ci-token" \
+            -H "Content-Type: application/json" \
+            -X POST \
+            -d '{"retentionDays":3,"pruneIntervalHours":12}' \
+            "http://127.0.0.1:8790/admin/uploads/retention" > /tmp/admin-uploads-retention.json
+
+          python3 - <<'PY'
+          import json
+          d=json.load(open('/tmp/admin-uploads-retention.json'))
+          assert d.get('ok') is True, d
+          assert d.get('retentionDays') == 3, d
+          assert d.get('pruneIntervalHours') == 12, d
+          print('admin/uploads/retention update ok')
+          PY
+
+          curl -fsS \
+            -H "Authorization: Bearer ci-token" \
+            "http://127.0.0.1:8790/admin/status" > /tmp/admin-status-after-uploads-update.json
+
+          python3 - <<'PY'
+          import json
+          d=json.load(open('/tmp/admin-status-after-uploads-update.json'))
+          db=d.get('db') or {}
+          assert db.get('uploadRetentionDays') == 3, d
+          assert db.get('uploadPruneIntervalHours') == 12, d
+          print('admin/status reflects upload settings update')
+          PY
+
       - name: Smoke test admin validate
         shell: bash
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - Added GitHub Actions workflow to build the UI and run a local-orbit smoke test (health, admin status, cache headers, events endpoint).
 - CI now also smoke-tests the WebSocket relay path (client ↔ anchor) to catch blank-thread regressions.
 - CI now smoke-tests `/admin/repair` safe actions and non-Tailscale `fixTailscaleServe` behavior to harden self-heal path coverage across environments.
+- CI now smoke-tests `/admin/uploads/retention` updates (retention + auto-cleanup interval) and verifies `/admin/status` reflects saved upload settings.
 
 ## 2026-02-08
 


### PR DESCRIPTION
## What/Why
Adds CI smoke coverage for the admin upload settings endpoint so regressions in retention/prune-interval updates are caught automatically.

- New CI step posts to `/admin/uploads/retention` with both settings.
- Asserts update response payload values.
- Asserts `/admin/status` reflects updated `uploadRetentionDays` and `uploadPruneIntervalHours`.
- Changelog updated.

Closes #66

## How to test
1. Run the GitHub Actions `ci` workflow for this branch.
2. Confirm `build-and-smoke` passes and includes the new upload settings smoke step.

## Validation run
- `~/.codex-pocket/bin/codex-pocket self-test` ✅
- `VITE_ZANE_LOCAL=1 bunx --bun vite build` ✅

## Risk assessment
- Low: CI workflow and changelog only.
- No runtime behavior changes.

## Rollback
- Revert this PR commit.
