### PR TITLE
Security phase 1: per-device token sessions + revoke APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - Admin uploads reporting: `/admin/uploads/stats` now includes last prune detail/source (manual/scheduled/unknown), surfaced in Admin Uploads UI.
 - Attachments: composer attachment chips now render small image thumbnails for faster visual verification before sending.
 - Admin uploads: auto-cleanup cadence is now configurable (1-168 hours) and visible in `/admin`, persisted with retention settings.
+- Security/Admin: phase-1 per-device token sessions added on the backend (`/admin/token/sessions*`) with create/list/revoke APIs and legacy-token auth compatibility.
 
 ### UX
 - UI: on mobile, the thread status legend is now available via a `?` button (iOS doesn't reliably show `title` tooltips).


### PR DESCRIPTION
## What/Why
This is phase 1 of per-device tokens: backend support for token sessions with revocation, while keeping the legacy global token fully compatible.

### Included
- New `token_sessions` DB table (hashed token storage, label, created/last-used/revoked timestamps).
- Auth now accepts either:
  - legacy global bearer token, or
  - an active token session value.
- New admin APIs:
  - `GET /admin/token/sessions`
  - `POST /admin/token/sessions/new` (returns one-time plain token)
  - `POST /admin/token/sessions/revoke`
- `GET /admin/status` now includes session counts (`tokenSessions.total` / `active`).
- Changelog update.

Closes #68

## How to test
1. With existing legacy token auth, confirm current app/admin behavior still works.
2. Create a session token:
   - `POST /admin/token/sessions/new` with `{ "label": "My iPhone" }`
3. Use returned token as bearer for `/admin/status`; request should succeed.
4. Revoke session via `/admin/token/sessions/revoke` and verify that same token now gets `401`.
5. Confirm legacy token still authenticates after revoking a session token.

## Validation run
- `bunx tsc --noEmit` ✅
- `~/.codex-pocket/bin/codex-pocket self-test` ✅
- `VITE_ZANE_LOCAL=1 bunx --bun vite build` ✅

## Risk assessment
- Medium: touches auth path in local-orbit.
- Mitigation: legacy token remains unchanged and still valid; session tokens are additive.
- No UI behavior changed in this PR.

## Rollback
- Revert this commit to return to legacy-token-only auth model.
