### PR TITLE
Admin: token session management UI (create/list/revoke)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - Attachments: composer attachment chips now render small image thumbnails for faster visual verification before sending.
 - Admin uploads: auto-cleanup cadence is now configurable (1-168 hours) and visible in `/admin`, persisted with retention settings.
 - Security/Admin: phase-1 per-device token sessions added on the backend (`/admin/token/sessions*`) with create/list/revoke APIs and legacy-token auth compatibility.
+- Admin: added token session management UI in `/admin` (create/list/revoke session tokens) with one-time token display/copy and active/revoked status.
 
 ### UX
 - UI: on mobile, the thread status legend is now available via a `?` button (iOS doesn't reliably show `title` tooltips).


### PR DESCRIPTION
## What/Why
Adds an Admin UI for phase-1 token sessions so operators can actually create, inspect, and revoke per-device tokens.

### Included
- New Token Sessions block in `/admin` (within advanced debug/security area).
- Create session token with a label (`/admin/token/sessions/new`).
- List sessions and status (`/admin/token/sessions`).
- Revoke active session (`/admin/token/sessions/revoke`).
- One-time token display + best-effort clipboard copy.
- Status chips for active/total session counts.
- Changelog update.

Closes #70

## How to test
1. Open `/admin` → Advanced Debug section.
2. Create a session token with label.
3. Confirm token appears once and session list refreshes.
4. Revoke an active session and confirm status becomes revoked.
5. Confirm existing admin controls still behave unchanged.

## Validation run
- `bunx tsc --noEmit` ✅
- `~/.codex-pocket/bin/codex-pocket self-test` ✅
- `VITE_ZANE_LOCAL=1 bunx --bun vite build` ✅

## Risk assessment
- Low/medium: admin UI integration with existing auth APIs.
- No protocol/db schema changes in this PR.

## Rollback
- Revert this commit to remove token-session UI while leaving backend APIs intact.
