### PR TITLE
Security: add read-only mode for token sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - Admin uploads: auto-cleanup cadence is now configurable (1-168 hours) and visible in `/admin`, persisted with retention settings.
 - Security/Admin: phase-1 per-device token sessions added on the backend (`/admin/token/sessions*`) with create/list/revoke APIs and legacy-token auth compatibility.
 - Admin: added token session management UI in `/admin` (create/list/revoke session tokens) with one-time token display/copy and active/revoked status.
+- Security: token sessions now support `read_only` mode; read-only sessions are blocked from write HTTP actions and WebSocket upgrades.
 
 ### UX
 - UI: on mobile, the thread status legend is now available via a `?` button (iOS doesn't reliably show `title` tooltips).

--- a/src/routes/Admin.svelte
+++ b/src/routes/Admin.svelte
@@ -37,6 +37,7 @@
   type TokenSession = {
     id: string;
     label: string;
+    mode: "full" | "read_only";
     createdAt: number;
     lastUsedAt: number;
     revokedAt: number | null;
@@ -73,6 +74,7 @@
   let tokenSessions = $state<TokenSession[]>([]);
   let loadingTokenSessions = $state(false);
   let tokenSessionLabel = $state("");
+  let tokenSessionMode = $state<"full" | "read_only">("full");
   let creatingTokenSession = $state(false);
   let createdSessionToken = $state<string | null>(null);
   let tokenSessionError = $state<string | null>(null);
@@ -213,7 +215,7 @@
       const res = await fetch("/admin/token/sessions/new", {
         method: "POST",
         headers,
-        body: JSON.stringify({ label: tokenSessionLabel }),
+        body: JSON.stringify({ label: tokenSessionLabel, mode: tokenSessionMode }),
       });
       const data = (await res.json().catch(() => null)) as null | { ok?: boolean; token?: string; error?: string };
       if (!res.ok || !data?.ok || !data.token) {
@@ -226,6 +228,7 @@
         // ignore
       }
       tokenSessionLabel = "";
+      tokenSessionMode = "full";
       stampAction("success", "Token session created");
       await loadTokenSessions();
       await loadStatus();
@@ -988,6 +991,11 @@
               bind:value={tokenSessionLabel}
               placeholder="Dane iPhone"
             />
+            <label for="token-session-mode">session mode</label>
+            <select id="token-session-mode" bind:value={tokenSessionMode}>
+              <option value="full">Full access</option>
+              <option value="read_only">Read-only</option>
+            </select>
             <div class="row buttons">
               <button type="button" onclick={createTokenSession} disabled={!auth.token || creatingTokenSession}>
                 {creatingTokenSession ? "Creating..." : "Create token session"}
@@ -1019,6 +1027,7 @@
                     </StatusChip>
                   </div>
                   <div class="hint mono">id: {session.id}</div>
+                  <div class="hint">mode: {session.mode === "read_only" ? "read-only" : "full access"}</div>
                   <div class="hint">created: {new Date(session.createdAt).toLocaleString()}</div>
                   <div class="hint">last used: {new Date(session.lastUsedAt).toLocaleString()}</div>
                   {#if session.revokedAt}


### PR DESCRIPTION
## What/Why
Implements optional read-only mode for token sessions and enforces it server-side for write actions.

### Included
- Token sessions now include `mode` (`full` or `read_only`) with DB migration-safe handling.
- Session creation API accepts `mode`.
- Session list API returns `mode`.
- Admin UI session creator now lets you choose mode.
- Read-only session enforcement:
  - write HTTP requests are denied,
  - WebSocket upgrades are denied for read-only sessions.
- Changelog update.

Closes #72

## How to test
1. Create a `read_only` token session from Admin.
2. Use read-only token to call `GET /admin/status` (should succeed).
3. Use same token for `POST /admin/pair/new` (should be denied).
4. Attempt WebSocket upgrade to `/ws` with same token (should be denied).
5. Verify `full` session tokens still perform write actions.

## Validation run
- `bunx tsc --noEmit` ✅
- `~/.codex-pocket/bin/codex-pocket self-test` ✅
- `VITE_ZANE_LOCAL=1 bunx --bun vite build` ✅
- Local integration check on temp port: read-only read pass, write denied, ws denied ✅

## Risk assessment
- Medium: auth behavior change for token sessions.
- Legacy token behavior remains unchanged.
- Read-only sessions are intentionally restricted from realtime ws path in this phase.

## Rollback
- Revert this commit to remove read-only session mode enforcement.
