### PR TITLE
Docs: update auth and pairing model for token sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - Admin: added token session management UI in `/admin` (create/list/revoke session tokens) with one-time token display/copy and active/revoked status.
 - Security: token sessions now support `read_only` mode; read-only sessions are blocked from write HTTP actions and WebSocket upgrades.
 - Pairing/Security: `/admin/pair/new` now mints a unique token session per pairing code instead of reusing the legacy shared token.
+- Docs: updated README/Admin/Security/Protocol docs to reflect token-session auth, read-only mode, and per-device pairing tokens.
 
 ### UX
 - UI: on mobile, the thread status legend is now available via a `?` button (iOS doesn't reliably show `title` tooltips).

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ We track the canonical backlog in GitHub Projects:
 Codex Pocket is a focused fork for a single use case: **run Codex locally on macOS and access it securely from iPhone over Tailscale**.
 
 Key differences:
-- **No Cloudflare dependency**: Codex Pocket uses a single local server (`local-orbit`) with a shared-token auth model.
+- **No Cloudflare dependency**: Codex Pocket uses a single local server (`local-orbit`) with token-based auth (legacy access token + per-device sessions).
 - **Tailnet-first exposure**: binds to `127.0.0.1` and is designed to be exposed via `tailscale serve` to devices on your tailnet (no public internet required).
-- **Simplified auth + pairing**: one bearer **Access Token** + short-lived one-time pairing QR in `/admin`.
+- **Simplified auth + pairing**: one legacy **Access Token** for bootstrap/admin plus short-lived pairing QR that mints per-device session tokens.
 - **Installer + lifecycle UX**: one-line installer, `launchd` integration (with background fallback), and a full `codex-pocket` CLI (`doctor/summary/urls/token/start/stop/restart/status/logs/pair/open-admin/ensure/smoke-test/update`).
 - **Local persistence**: SQLite-backed event log + replay endpoints powering the Review UI.
 - **iPhone-first usability**: default Enter = newline (send via Cmd/Ctrl+Enter), plus mobile-oriented UI fixes.
@@ -114,9 +114,12 @@ This repo includes a GitHub Actions workflow (`.github/workflows/ci.yml`) that b
 
 ## Security Model
 - You must be on the same Tailscale tailnet as the Mac.
-- A single bearer token protects the WebSocket and admin API.
-- Pairing: `/admin` can mint a short-lived one-time pairing code (shown as a QR).
-  - Scan it on iPhone to store the bearer token locally.
+- Auth supports:
+  - legacy Access Token (bootstrap/admin),
+  - per-device token sessions (create/list/revoke in `/admin`).
+- Pairing: `/admin` mints a short-lived one-time pairing code (shown as QR).
+  - Consuming the code on iPhone returns a unique per-device session token.
+  - Session tokens can be revoked individually in `/admin`.
 
 ## Why Tailscale?
 

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -11,7 +11,15 @@ Open `/admin` in the browser.
 ## Pair iPhone
 - On first sign-in, `/admin` auto-generates a short-lived pairing QR.
 - Use "Regenerate pairing code" to mint a fresh QR (codes are one-time and expire).
-- Scan from iPhone to sign in without manually typing the token.
+- Scan from iPhone to sign in without manually typing a token.
+- Pairing now mints a unique per-device token session for that device.
+
+## Token sessions
+- `/admin` includes token session management:
+  - create a labeled token session,
+  - choose `full` or `read-only`,
+  - list active/revoked sessions,
+  - revoke a single session without rotating everything.
 
 ## Thread titles (Codex Desktop sync)
 Codex Pocket keeps thread titles in sync with the Codex desktop app by reading:
@@ -43,4 +51,4 @@ Notes:
 
 ## Debug tools
 - "Debug" shows the last stored events (redacted). This helps diagnose issues where threads appear but transcripts are blank.
-- "Rotate access token" rotates the bearer token and disconnects all devices. After rotating, you must sign in again on Mac/iPhone.
+- "Rotate access token" rotates the legacy bootstrap token. Session-token devices remain valid unless revoked.

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -89,6 +89,7 @@ local-orbit will broadcast the message to all anchors so the anchor can observe 
 - `POST /pair/consume` (no auth)
   - body: `{ "code": "..." }`
   - returns `{ "token": "..." }`
+  - token is a newly minted per-device token session
   - codes are one-time use and expire.
 
 ## Persistence
@@ -104,4 +105,15 @@ local-orbit stores events in SQLite (default `~/.codex-pocket/codex-pocket.db`).
   - returns the last N stored event payloads (redacted).
 
 - `POST /admin/token/rotate` (auth required)
-  - rotates the Access Token, persists it to `config.json` (if configured), clears pairing codes, and disconnects clients.
+  - rotates the legacy Access Token, persists it to `config.json` (if configured), clears pairing codes, and disconnects clients.
+
+- `GET /admin/token/sessions` (auth required)
+  - returns token sessions (id, label, mode, created/last-used/revoked timestamps).
+
+- `POST /admin/token/sessions/new` (auth required)
+  - body: `{ "label"?: string, "mode"?: "full" | "read_only" }`
+  - returns `{ ok, token, session }` where `token` is only shown once.
+
+- `POST /admin/token/sessions/revoke` (auth required)
+  - body: `{ "id": "..." }`
+  - revokes that token session.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -4,7 +4,7 @@ Codex Pocket gives remote control of a local Codex session. Treat it like remote
 
 ## Threat Model
 - Unauthorized control of your Codex session (can read/write files, run commands via Codex approvals).
-- Token leakage (bearer token gives access to WebSocket + admin APIs).
+- Token leakage (legacy token or device-session tokens can grant remote access).
 - Tailnet compromise (an attacker with access to your Tailscale network can attempt access).
 - Sensitive data exposure via logs or persisted events.
 
@@ -16,15 +16,21 @@ Codex Pocket gives remote control of a local Codex session. Treat it like remote
 - Prefer Tailscale ACLs to restrict which devices/users can reach your Mac.
 
 ### Authentication
-- A single bearer token (`ZANE_LOCAL_TOKEN`) protects:
+- A legacy bearer token (`ZANE_LOCAL_TOKEN`) plus per-device session tokens protect:
   - WebSocket `/ws`
   - WebSocket `/ws/anchor`
   - Admin endpoints `/admin/*`
   - Event API `/threads/:id/events`
 
+- Token sessions can be created/listed/revoked from `/admin`.
+- Token session mode:
+  - `full`: normal read/write access
+  - `read_only`: read-only HTTP access; write endpoints and websocket upgrades are denied
+
 ### Pairing
 - Pairing uses a short-lived, one-time code.
 - The code can be shown as a QR from `/admin` and consumed on iPhone at `/pair`.
+- Pair consume returns a unique per-device session token (not the legacy bootstrap token).
 - Pairing code TTL is configurable via `ZANE_LOCAL_PAIR_TTL_SEC` (default 300s).
 
 ### Local persistence
@@ -33,12 +39,13 @@ Codex Pocket gives remote control of a local Codex session. Treat it like remote
 
 ## Operational Guidance
 - Treat the bearer token like a password.
-  - Rotate it if an iPhone is lost, or if you suspect compromise.
+  - Rotate the legacy token if bootstrap/admin token compromise is suspected.
+  - Revoke individual token sessions when a paired device is lost/compromised.
 - Keep `tailscale serve` exposure limited to your tailnet.
 - Consider enabling Tailscale ACLs so only your phone can reach this service.
 - Be mindful of what you ask Codex to print or diff: it can end up in logs and the SQLite event store.
 
 ## Known Limitations (Current)
-- No per-user accounts: single shared token.
+- No per-user identity/accounts; access is still token-based.
 - No end-to-end encryption above TLS: traffic is secured by Tailscale HTTPS/WSS.
 - Event persistence is plaintext on disk.


### PR DESCRIPTION
## What/Why
Docs-only PR to align project documentation with the shipped token-session security model and pairing behavior.

### Updated docs
- `README.md`
- `docs/ADMIN.md`
- `docs/PROTOCOL.md`
- `docs/SECURITY.md`
- `CHANGELOG.md`

### Changes
- Replaced stale "single shared token" wording with legacy + token-session model.
- Documented token sessions create/list/revoke and read-only mode semantics.
- Clarified pairing now mints per-device session tokens.
- Clarified legacy token rotate behavior.

Closes #76

## Validation run
- `~/.codex-pocket/bin/codex-pocket self-test` ✅
- `VITE_ZANE_LOCAL=1 bunx --bun vite build` ✅

## Risk assessment
- Low: documentation only.

## Rollback
- Revert this commit.
