### PR TITLE
Security: read-only websocket mode with RPC write guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - Security: token sessions now support `read_only` mode; read-only sessions are blocked from write HTTP actions and WebSocket upgrades.
 - Pairing/Security: `/admin/pair/new` now mints a unique token session per pairing code instead of reusing the legacy shared token.
 - Docs: updated README/Admin/Security/Protocol docs to reflect token-session auth, read-only mode, and per-device pairing tokens.
+- Security: read-only token sessions can now connect to WebSocket for live reads, while mutating client RPC methods are denied with explicit errors.
 
 ### UX
 - UI: on mobile, the thread status legend is now available via a `?` button (iOS doesn't reliably show `title` tooltips).

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -25,7 +25,7 @@ Codex Pocket gives remote control of a local Codex session. Treat it like remote
 - Token sessions can be created/listed/revoked from `/admin`.
 - Token session mode:
   - `full`: normal read/write access
-  - `read_only`: read-only HTTP access; write endpoints and websocket upgrades are denied
+  - `read_only`: read-only HTTP access; write endpoints are denied and mutating websocket RPC calls are denied
 
 ### Pairing
 - Pairing uses a short-lived, one-time code.


### PR DESCRIPTION
## What/Why
Implements read-only websocket mode: read-only token sessions can connect for live updates, but mutating client RPCs are rejected server-side.

### Included
- Removed websocket-upgrade deny for read-only token sessions.
- Added read-only RPC safety guard in ws message handler:
  - allows read-safe RPC methods,
  - rejects mutating methods with explicit JSON-RPC error response.
- Updated security docs + changelog.

Closes #78

## How to test
1. Create read-only token session.
2. Connect to `/ws` using that token (should connect).
3. Send mutating RPC (e.g. `turn/start`) and verify explicit error response.
4. Confirm full-access sessions unchanged.

## Validation run
- `bunx tsc --noEmit` ✅
- `~/.codex-pocket/bin/codex-pocket self-test` ✅
- `VITE_ZANE_LOCAL=1 bunx --bun vite build` ✅
- local integration check with `ws` client: read-only ws connect + mutating RPC denied ✅

## Risk assessment
- Medium: websocket auth/routing behavior for read-only sessions.
- Full-access and legacy tokens unchanged.

## Rollback
- Revert this commit.
