### PR TITLE
Docs: sync BACKLOG with completed P0 reliability items

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -58,11 +58,8 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 - Pairing: `/admin/pair/new` now mints per-device session tokens instead of returning the legacy shared token.
 - Security/read-only UX: read-only sessions can connect to WebSocket for live reads; mutating RPC methods are denied explicitly.
 - CI: added smoke coverage for token-session security behavior (pairing token semantics + read-only guards).
-
-## P0 (Stability)
-
-- CI smoke coverage hardening (remaining edge paths).
-- Update reliability with stale processes (remaining hardening).
+- CLI/update: stale owned listeners now use bounded SIGKILL fallback cleanup (including symlink-safe ownership detection) to reduce restart flakiness.
+- CI: added edge guards for one-time pair-code consumption and immediate auth denial after token-session revocation.
 
 ## P4 (Platform)
 


### PR DESCRIPTION
## Summary
Closes #88.

Syncs `BACKLOG.md` with Project 2 after completing and merging the remaining P0 stability items.

## What changed
- Added recently-done bullets for:
  - stale-process cleanup hardening (`#84` / PR #85)
  - CI edge guards for pair one-time consume + revoked-session denial (`#86` / PR #87)
- Removed completed P0 active items from the backlog section.
- `P4` native iOS roadmap remains as the only active backlog item.

## How to test
- Docs-only change; verify `BACKLOG.md` content aligns with Project 2 `Todo` state.

## Risk assessment
- Low (documentation sync only).

## Rollback
- Revert this PR.
