### PR TITLE
Docs: add native iOS roadmap and phased milestones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project started as a local-only fork inspired by **Zane** by Z. Siddiqi. Se
 - UI/Admin/CLI: detect upstream Codex app-server auth invalidation and surface a clear recovery warning.
 - Admin: add a limited remote CLI runner for safe `codex-pocket` commands (with output capture).
 - Docs/UX: added `docs/ADMIN_REDESIGN_PROPOSAL.md` and aligned backlog/project planning for phased Admin + Settings UI redesign work.
+- Docs: added `docs/NATIVE_IOS_ROADMAP.md` with phased native-client milestones, constraints, and decision gates.
 - Docs/Repo: added `CONTRIBUTING.md` with an explicit ff-only sync policy, PR/testing expectations, and a local pre-release clean-tree check script (`scripts/ci/check-clean-tree.sh`).
 - UX: added one-tap composer quick-reply shortcuts (default `Proceed`/`Elaborate`) plus a `/settings` editor to customize and persist preset labels/text per device.
 - Settings redesign follow-up: `/settings` now uses a responsive two-column card grid on desktop (single-column mobile) with core controls prioritized above secondary account/about details.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ If anything doesn’t work, run:
 - Troubleshooting/FAQ: [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md)
 - Architecture: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
 - CI: [`docs/CI.md`](docs/CI.md)
+- Native iOS roadmap: [`docs/NATIVE_IOS_ROADMAP.md`](docs/NATIVE_IOS_ROADMAP.md)
 - Differences from Zane: [`docs/DIFFERENCES_FROM_ZANE.md`](docs/DIFFERENCES_FROM_ZANE.md)
 - Development: [`docs/DEVELOPMENT.md`](docs/DEVELOPMENT.md)
 - Contributing: [`CONTRIBUTING.md`](CONTRIBUTING.md)
@@ -220,6 +221,7 @@ Note about the Codex desktop app:
 - Protocol: [`docs/PROTOCOL.md`](docs/PROTOCOL.md)
 - Security hardening: [`docs/HARDENING.md`](docs/HARDENING.md)
 - Troubleshooting: [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md)
+- Native iOS roadmap: [`docs/NATIVE_IOS_ROADMAP.md`](docs/NATIVE_IOS_ROADMAP.md)
 - Changelog: [`CHANGELOG.md`](CHANGELOG.md)
 
 ## Attribution

--- a/docs/NATIVE_IOS_ROADMAP.md
+++ b/docs/NATIVE_IOS_ROADMAP.md
@@ -1,0 +1,107 @@
+# Native iOS Roadmap
+
+This roadmap defines a phased path for a native iOS client while keeping current web reliability first.
+
+Status:
+- Web reliability/docs/CI are currently green.
+- Native iOS work remains optional (`P4`) and should stay incremental.
+
+## Goals
+
+- Replicate core Codex Pocket behavior in a native SwiftUI client.
+- Keep tailnet-only networking assumptions.
+- Preserve existing backend/API model (`local-orbit`) and pairing flow.
+- Add native-only value where web cannot match well (notifications/background UX).
+
+## Non-Goals (for first milestones)
+
+- App Store production release.
+- Cloud relay/public-internet support.
+- Major backend protocol redesign.
+
+## Constraints
+
+- Security model stays tailnet-only + token-session auth.
+- Pairing remains short-lived, QR-based, one-time consumable.
+- Existing web client remains supported in parallel.
+
+## Milestones
+
+### M0: Discovery + Contract Freeze (Docs/Test Only)
+- Confirm API contract used by iOS:
+  - `/pair/consume`
+  - `/admin/status` (device/server health)
+  - `/threads/:id/events`
+  - `/ws` message flow (read + write paths)
+- Define iOS parity checklist against current web behavior:
+  - thread list
+  - thread open/history replay
+  - send message
+  - attachment upload/send
+- Deliverable:
+  - frozen API checklist + smoke test matrix for iOS parity.
+
+### M1: Pairing + Session Bootstrap (SwiftUI Skeleton)
+- Build initial app shell with:
+  - QR scanner for pair URL/code
+  - pair consume call
+  - secure token storage in Keychain
+  - basic connection status surface
+- Acceptance:
+  - fresh install can pair with existing `/admin` QR flow
+  - app can fetch authenticated `/admin/status`.
+
+### M2: Read Path Parity
+- Implement:
+  - thread list
+  - thread history view backed by events replay
+  - websocket read updates
+- Acceptance:
+  - old thread history loads
+  - live updates display without manual refresh
+  - read-only token mode behavior is explicit in UI.
+
+### M3: Write Path Parity
+- Implement:
+  - composer send flow
+  - write actions through websocket/API path
+  - attachment selection/upload path
+- Acceptance:
+  - send message and receive streamed/turn-complete updates
+  - image attachment can be uploaded and rendered in thread
+  - errors are surfaced with actionable retry messaging.
+
+### M4: Native Value Additions
+- Implement iOS-specific improvements:
+  - notifications for:
+    - approval required
+    - turn complete
+    - turn failure
+  - better background/resume behavior than mobile Safari
+- Acceptance:
+  - notifications arrive for above event classes
+  - app resumes cleanly to current thread state after background.
+
+## Ask-Me-First Decision Gates
+
+Pause and confirm before implementing any of the following:
+- changes to auth/token model or approval gating behavior
+- backend API changes that break existing web clients
+- new external integrations/services for notifications or relay
+- large dependency/toolchain shifts.
+
+## Testing Strategy
+
+- Keep existing web CI/self-tests mandatory.
+- Add iOS parity smoke tests milestone-by-milestone:
+  - pair success/failure
+  - thread list fetch
+  - history replay
+  - send + streamed update
+  - attachment upload round-trip.
+
+## Delivery Strategy
+
+- One small PR per milestone slice.
+- Keep PRs reviewable and avoid mixed refactors.
+- Update this roadmap and `BACKLOG.md` after each milestone lands.


### PR DESCRIPTION
## Summary
Closes #90.

Adds a dedicated native iOS roadmap document so the remaining P4 backlog item is concrete and implementation-ready in phases.

## What changed
- Added `docs/NATIVE_IOS_ROADMAP.md` with:
  - goals/non-goals,
  - constraints,
  - phased milestones (M0-M4),
  - ask-me-first decision gates,
  - testing + delivery strategy.
- Added roadmap link in both README docs indexes.
- Updated `CHANGELOG.md` (Unreleased docs note).

## How to test
- Docs-only behavior; verify links render and roadmap is clear/actionable.
- Local guard run: `~/.codex-pocket/bin/codex-pocket self-test`.

## Risk assessment
- Low (documentation only).

## Rollback
- Revert this PR.
