### PR TITLE
Docs: sync BACKLOG after iOS roadmap completion

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -60,7 +60,8 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 - CI: added smoke coverage for token-session security behavior (pairing token semantics + read-only guards).
 - CLI/update: stale owned listeners now use bounded SIGKILL fallback cleanup (including symlink-safe ownership detection) to reduce restart flakiness.
 - CI: added edge guards for one-time pair-code consumption and immediate auth denial after token-session revocation.
+- Docs: added a phased native iOS roadmap (`docs/NATIVE_IOS_ROADMAP.md`) with constraints, milestones, and decision gates.
 
-## P4 (Platform)
+## Active Items
 
-- Native iOS app (optional): better background behavior, push notifications for “approval required”, better file picker.
+- None currently open in Project 2.


### PR DESCRIPTION
## Summary
Closes #92.

Syncs `BACKLOG.md` with Project 2 after completing the native iOS roadmap docs deliverable.

## What changed
- Added recently-done note for `docs/NATIVE_IOS_ROADMAP.md`.
- Replaced stale active P4 entry with an explicit "no active items" state.

## How to test
- Docs-only: verify `BACKLOG.md` aligns with Project 2 (no `Todo` items).

## Risk assessment
- Low (documentation only).

## Rollback
- Revert this PR.
