### PR TITLE
fix: improve local dev auth mode and Orbit WS defaults

### DIFF
--- a/src/lib/auth.svelte.ts
+++ b/src/lib/auth.svelte.ts
@@ -8,7 +8,9 @@ const STORE_KEY = "__zane_auth_store__";
 const STORAGE_KEY = "zane_auth_token";
 const REFRESH_STORAGE_KEY = "zane_refresh_token";
 const AUTH_BASE_URL = (import.meta.env.AUTH_URL ?? "").replace(/\/$/, "");
-const LOCAL_MODE = import.meta.env.VITE_ZANE_LOCAL === "1";
+// In Codex Pocket local installs, AUTH_URL is intentionally unset.
+// Treat that as local mode even if VITE_ZANE_LOCAL was not passed to Vite.
+const LOCAL_MODE = import.meta.env.VITE_ZANE_LOCAL === "1" || AUTH_BASE_URL.length === 0;
 
 type AuthStatus = "loading" | "signed_out" | "signed_in" | "needs_setup";
 

--- a/src/routes/Pair.svelte
+++ b/src/routes/Pair.svelte
@@ -3,7 +3,8 @@
   import { config } from "../lib/config.svelte";
   import { navigate } from "../router";
 
-  const LOCAL_MODE = import.meta.env.VITE_ZANE_LOCAL === "1";
+  const AUTH_BASE_URL = (import.meta.env.AUTH_URL ?? "").replace(/\/$/, "");
+  const LOCAL_MODE = import.meta.env.VITE_ZANE_LOCAL === "1" || AUTH_BASE_URL.length === 0;
 
   let status = $state<"loading" | "ok" | "error">("loading");
   let error = $state<string | null>(null);

--- a/src/routes/Settings.svelte
+++ b/src/routes/Settings.svelte
@@ -72,7 +72,8 @@
     quickReplySaveNote = "Saved.";
   }
   import { anchors } from "../lib/anchors.svelte";
-  const LOCAL_MODE = import.meta.env.VITE_ZANE_LOCAL === "1";
+  const AUTH_BASE_URL = (import.meta.env.AUTH_URL ?? "").replace(/\/$/, "");
+  const LOCAL_MODE = import.meta.env.VITE_ZANE_LOCAL === "1" || AUTH_BASE_URL.length === 0;
 
   const UI_COMMIT = String(import.meta.env.VITE_CODEX_POCKET_COMMIT ?? "");
   const UI_BUILT_AT = String(import.meta.env.VITE_CODEX_POCKET_BUILT_AT ?? "");


### PR DESCRIPTION
## Summary
- treat empty AUTH_URL as local mode in auth-related routes
- in local loopback dev, default Orbit WS target to 127.0.0.1:8790 instead of Vite origin
- auto-migrate stale saved WS URLs that point to the current Vite dev server port

## Why
Running the UX locally on http://localhost:5173 required manual localStorage overrides and could show "Auth service unavailable".

## Validation
- bunx --bun eslint src/lib/auth.svelte.ts src/lib/config.svelte.ts src/routes/Pair.svelte src/routes/Settings.svelte
- bun run build