### PR TITLE
fix: keep thread/read from bumping thread last-activity

### DIFF
--- a/src/lib/messages.svelte.ts
+++ b/src/lib/messages.svelte.ts
@@ -589,7 +589,9 @@ class MessagesStore {
         null;
 
       if (threadId && Array.isArray(turns)) {
-        this.#touch(threadId);
+        // Do not mark thread/read thread/get responses as fresh activity.
+        // These payloads are often metadata/history fetches and can make many
+        // threads incorrectly appear as "active now" in the thread list.
         // Do not require `existing.length === 0` here.
         // We can receive live `item/*` messages immediately after subscribing, which would
         // make `existing` non-empty and inadvertently block history loading, resulting in


### PR DESCRIPTION
## Summary
- stop calling `touch(threadId)` when processing `thread/read` and `thread/get` history payloads
- keep a clarifying comment about why these responses should not count as fresh activity

## Why
Issue #97 reports many threads showing the current time and reordering incorrectly. `thread/read` history fetches can happen on refresh and should not update last-activity.

Fixes #97

## Validation
- bunx --bun eslint src/lib/messages.svelte.ts
