### PR TITLE
fix(admin,docs): keep single advanced CLI panel and clarify PATH usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ We track the canonical backlog in GitHub Projects:
 
 ## Common First-Run Issues
 
+- **`codex-pocket: command not found`**
+  - The CLI is installed at `~/.codex-pocket/bin/codex-pocket`.
+  - Quick run: `~/.codex-pocket/bin/codex-pocket summary`
+  - Add to PATH (zsh):
+    - `echo 'export PATH="$HOME/.codex-pocket/bin:$PATH"' >> ~/.zshrc`
+    - `exec zsh`
+  - From this repo, run `./bin/codex-pocket ...` (if you `cd bin`, use `./codex-pocket`, not `codex-pocket`).
+
 - **"Serve is not enabled on your tailnet"**
   - Tailscale may require you to explicitly enable Serve in your tailnet admin settings.
   - Run `tailscale serve --bg http://127.0.0.1:8790` and follow the link Tailscale prints to enable Serve.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -5,6 +5,38 @@ The `codex-pocket` CLI manages the service and talks to the local Admin API.
 Binary location after install:
 - `~/.codex-pocket/bin/codex-pocket` (wrapper that delegates to the repo copy in `~/.codex-pocket/app/bin/codex-pocket`)
 
+## Running the CLI
+
+Preferred (installed copy):
+
+```bash
+codex-pocket summary
+```
+
+If your shell says `command not found`, either:
+
+- call it directly: `~/.codex-pocket/bin/codex-pocket summary`, or
+- add it to PATH (`~/.zshrc` on macOS zsh):
+
+```bash
+echo 'export PATH="$HOME/.codex-pocket/bin:$PATH"' >> ~/.zshrc
+exec zsh
+```
+
+Repo-local development usage:
+
+```bash
+./bin/codex-pocket summary
+```
+
+Inside the `bin/` directory, use `./codex-pocket` (shells do not run `.` by default).
+
+Custom home installs (`CODEX_POCKET_HOME`) use:
+
+```bash
+$CODEX_POCKET_HOME/bin/codex-pocket summary
+```
+
 ## Most-Used Commands
 
 - `codex-pocket summary`

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -6,6 +6,13 @@
 curl -fsSL https://raw.githubusercontent.com/ddevalco/codex-pocket/main/scripts/install-local.sh | bash
 ```
 
+Use a custom install location (optional):
+
+```bash
+CODEX_POCKET_HOME="$HOME/my-pocket" \
+	curl -fsSL https://raw.githubusercontent.com/ddevalco/codex-pocket/main/scripts/install-local.sh | bash
+```
+
 The installer:
 - checks dependencies (git, bun, tailscale)
 - offers to run `tailscale up` if needed
@@ -25,6 +32,33 @@ Notes:
 - Tailnet access: `https://<your-mac-magicdns-host>/`
 - Admin: `/admin`
 - CLI: `~/.codex-pocket/bin/codex-pocket` (a thin wrapper that delegates to `~/.codex-pocket/app/bin/codex-pocket`)
+
+### Make `codex-pocket` available in your shell
+
+If `codex-pocket` prints `command not found`, your shell PATH does not include the install bin directory yet.
+
+zsh (default on macOS):
+
+```bash
+echo 'export PATH="$HOME/.codex-pocket/bin:$PATH"' >> ~/.zshrc
+exec zsh
+```
+
+bash:
+
+```bash
+echo 'export PATH="$HOME/.codex-pocket/bin:$PATH"' >> ~/.bashrc
+source ~/.bashrc
+```
+
+Quick alternatives (no shell config):
+
+```bash
+~/.codex-pocket/bin/codex-pocket summary
+./bin/codex-pocket summary   # from repo root
+```
+
+Note: shells do not execute from the current directory by name. Inside `bin/`, run `./codex-pocket`, not `codex-pocket`.
 
 ## Tailscale Setup (Mac + iPhone)
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -11,6 +11,31 @@ This project is designed to be local-first and tailnet-only. When something goes
 
 ## Common Issues
 
+### `codex-pocket: command not found`
+
+This means your shell PATH does not include the install bin directory yet.
+
+Immediate workaround:
+
+```bash
+~/.codex-pocket/bin/codex-pocket summary
+```
+
+Permanent fix (zsh/macOS):
+
+```bash
+echo 'export PATH="$HOME/.codex-pocket/bin:$PATH"' >> ~/.zshrc
+exec zsh
+```
+
+If you are running from the git repo, use:
+
+```bash
+./bin/codex-pocket summary
+```
+
+If you `cd bin`, run `./codex-pocket`, not `codex-pocket`.
+
 ### Admin Page Asks For Access Token
 
 Get the current token:

--- a/src/routes/Admin.svelte
+++ b/src/routes/Admin.svelte
@@ -910,57 +910,6 @@
         <div class="section stack">
           <div class="section-header">
             <div>
-              <span class="section-title">Remote CLI</span>
-              <div class="section-subtitle">Run a limited set of safe commands.</div>
-            </div>
-          </div>
-          <div class="section-body stack">
-            <div class="row buttons">
-              <label class="field">
-                <span>Command</span>
-                <select bind:value={cliSelected} disabled={cliRunning || cliCommands.length === 0}>
-                  {#each cliCommands as cmd (cmd.id)}
-                    <option value={cmd.id}>
-                      {cmd.label}{cmd.risky ? " (disruptive)" : ""}
-                    </option>
-                  {/each}
-                </select>
-              </label>
-              <button class="btn" type="button" onclick={runCliCommand} disabled={!auth.token || cliRunning || !cliSelected}>
-                {cliRunning ? "Running..." : "Run"}
-              </button>
-            </div>
-            {#if cliSelected}
-              {#each cliCommands as cmd (cmd.id)}
-                {#if cmd.id === cliSelected}
-                  <div class="hint">{cmd.description}</div>
-                  {#if cmd.risky}
-                    <div class="hint hint-error">This command may disconnect the admin session.</div>
-                  {/if}
-                {/if}
-              {/each}
-            {/if}
-            {#if cliError}
-              <p class="hint hint-error">{cliError}</p>
-            {/if}
-            {#if cliOutput}
-              <pre class="cli-output">{cliOutput}</pre>
-            {/if}
-            {#if cliPairUrl}
-              <div class="kv" style="margin-top: var(--space-md);">
-                <div class="k">Pair link</div>
-                <div class="v"><a href={cliPairUrl}>{cliPairUrl}</a></div>
-              </div>
-              {#if cliPairQrObjectUrl}
-                <div class="qr"><img alt="Pairing QR code" src={cliPairQrObjectUrl} /></div>
-              {/if}
-            {/if}
-          </div>
-        </div>
-
-        <div class="section stack">
-          <div class="section-header">
-            <div>
               <span class="section-title">Pair iPhone</span>
               <div class="section-subtitle">Scan to connect a new device.</div>
             </div>


### PR DESCRIPTION
## Summary
- remove duplicate top-level Remote CLI panel in Admin
- keep Advanced (collapsed) Remote CLI section as single complete CLI surface
- add explicit CLI PATH guidance and invocation examples in docs

## Why
- avoids duplicate controls in Admin UI
- reduces user confusion when codex-pocket is not on shell PATH

## Validation
- npm run build
- verified Advanced CLI section retains command picker, run action, descriptions/risky warning, output/error, and pair link/QR
