### PR TITLE
fix(anchor): resolve bun path for autostart in launchd envs

### DIFF
--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -380,6 +380,8 @@ cat > "$PLIST" <<PLISTXML
     <string>${APP_DIR}/app/services/anchor</string>
     <key>ZANE_LOCAL_ANCHOR_LOG</key>
     <string>${ANCHOR_LOG}</string>
+    <key>ZANE_LOCAL_ANCHOR_CMD</key>
+    <string>${BUN_BIN}</string>
     <key>ANCHOR_HOST</key>
     <string>127.0.0.1</string>
   <key>ANCHOR_PORT</key>
@@ -560,6 +562,8 @@ cat > "$PLIST" <<PLISTXML
     <string>${APP_DIR}/app/services/anchor</string>
     <key>ZANE_LOCAL_ANCHOR_LOG</key>
     <string>${ANCHOR_LOG}</string>
+    <key>ZANE_LOCAL_ANCHOR_CMD</key>
+    <string>${BUN_BIN}</string>
     <key>ANCHOR_HOST</key>
     <string>127.0.0.1</string>
     <key>ANCHOR_PORT</key>


### PR DESCRIPTION
## Summary
- fix Anchor autostart failures when local-orbit runs under launchd with a minimal PATH
- add runtime anchor command resolution in local-orbit (`process.execPath`, `Bun.which`, common bun paths)
- pass absolute `ZANE_LOCAL_ANCHOR_CMD` from installer launchd plist generation

## Context
- addresses issue #96 (`Executable not found in $PATH: "bun"`)

## Validation
- npm run build
