### PR TITLE
docs: enforce GitHub issue/project tracking + recommendation backlog

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Bug report
+description: Report a defect or regression.
+title: "bug: "
+labels:
+  - type:bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is broken?
+      placeholder: Describe the issue clearly and concisely.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Reproduction steps
+      description: How can we reproduce this reliably?
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: Device/OS/browser/app version details.
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / diagnostics
+      description: Relevant output from diagnostics, admin status, or logs.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Canonical backlog board (Project 2)
+    url: https://github.com/users/ddevalco/projects/2
+    about: Check roadmap status and planning columns.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,45 @@
+name: Feature request
+description: Propose a new capability or improvement.
+title: "feature: "
+labels:
+  - type:feature
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What user/job-to-be-done is not served today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the desired behavior and UX.
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - p0
+        - p1
+        - p2
+        - p3
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Define testable outcomes.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks / trade-offs

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -6,6 +6,10 @@ This file mirrors the canonical backlog, which lives in **GitHub Projects**:
 
 If the two ever disagree, treat GitHub Projects as the source of truth and update this file to match.
 
+Issues are canonical for work items:
+
+- https://github.com/ddevalco/codex-pocket/issues
+
 ## Recently Done
 
 - CI: added an explicit `/admin/validate` smoke check (auth required).
@@ -65,4 +69,10 @@ If the two ever disagree, treat GitHub Projects as the source of truth and updat
 
 ## Active Items
 
-- None currently open in Project 2.
+- Reliability: durable outbox + idempotency for mutating RPCs (P1, #105)
+- Observability: run timeline + failure reason counters in admin status (P1, #106)
+- Away mode: blocked-turn push alerts for approvals/user-input (P2, #107)
+- Orchestration UX: prompt/agent presets with import/export + dropdown apply (P2, #108)
+- Multi-agent workflows: first-class helper-agent actions and preset profiles (P3, #109)
+
+Source and implementation notes: [`docs/RECOMMENDATIONS.md`](docs/RECOMMENDATIONS.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,28 @@ git config --global fetch.prune true
 - Update docs when behavior changes.
 - Update `CHANGELOG.md` for user-visible changes.
 
+## Backlog + Issue Tracking (Required)
+
+- GitHub is the canonical system for planning and tracking:
+	- Issues: https://github.com/ddevalco/codex-pocket/issues
+	- Project board: https://github.com/users/ddevalco/projects/2
+- Every feature/bug/chore starts as a GitHub issue (use templates).
+- Every PR must reference its issue (`Fixes #<id>` or `Refs #<id>`).
+- Every open issue should be assigned to exactly one status column in Project 2.
+- `BACKLOG.md` is a mirror for quick in-repo visibility; if it diverges, GitHub wins.
+
+Recommended label set:
+
+- `type:bug`, `type:feature`, `type:reliability`, `type:docs`
+- `priority:p0`, `priority:p1`, `priority:p2`
+- `area:ui`, `area:local-orbit`, `area:anchor`, `area:protocol`, `area:ci`
+
+Project hygiene cadence:
+
+- During triage: create/update issue + labels + project status.
+- Before opening PR: verify issue is in `In Progress`.
+- After merge: close issue and move to `Done`.
+
 PR description should include:
 - what/why
 - how to test

--- a/README.md
+++ b/README.md
@@ -56,6 +56,22 @@ We track the canonical backlog in GitHub Projects:
 
 - https://github.com/users/ddevalco/projects/2
 
+### Issues (Canonical)
+
+All bugs, features, and reliability work are tracked as GitHub Issues:
+
+- https://github.com/ddevalco/codex-pocket/issues
+
+Workflow rules:
+
+- Open an issue before starting work.
+- Link every PR to an issue (`Fixes #...` or `Refs #...`).
+- Keep issue status in sync with Project 2.
+
+Prioritized engineering recommendations are maintained in:
+
+- [`docs/RECOMMENDATIONS.md`](docs/RECOMMENDATIONS.md)
+
 ## Common First-Run Issues
 
 - **`codex-pocket: command not found`**

--- a/docs/RECOMMENDATIONS.md
+++ b/docs/RECOMMENDATIONS.md
@@ -1,0 +1,147 @@
+# Recommendations (Prioritized)
+
+Date: 2026-02-15
+
+This document lays out recommended work from the architecture and protocol review.
+
+## Tracking Policy
+
+- Canonical tracker: GitHub Issues
+  - https://github.com/ddevalco/codex-pocket/issues
+- Canonical planning board: GitHub Project 2
+  - https://github.com/users/ddevalco/projects/2
+- For each item below:
+  1. Create an issue from the title.
+  2. Apply labels (`type:*`, `priority:*`, `area:*`).
+  3. Add to Project 2 and set status.
+  4. Link PR with `Fixes #<issue>`.
+
+## P1 — Reliability (Do First)
+
+### 1) Durable outbox + idempotency for mutating RPCs
+
+Issue: #105
+
+Issue title:
+- `Reliability: durable outbox + idempotency keys for mutating RPCs`
+
+Why:
+- Prevent lost/duplicated user actions on reconnects (turn start, approvals, user-input responses).
+
+Scope:
+- Add a client outbox persisted locally.
+- Tag mutating RPCs with idempotency keys.
+- Replay safely after reconnect.
+- Suppress duplicate application on server/relay side.
+
+Acceptance criteria:
+- Disconnect/reconnect during `turn/start` does not lose or duplicate turn start.
+- Disconnect/reconnect during approval response does not send conflicting decisions.
+- Disconnect/reconnect during user-input response preserves submitted answers exactly once.
+
+Suggested labels:
+- `type:reliability`, `priority:p1`, `area:protocol`, `area:local-orbit`, `area:ui`
+
+### 2) Run timeline + failure reason counters
+
+Issue: #106
+
+Issue title:
+- `Observability: admin run timeline and failure reason counters`
+
+Why:
+- Improve remote debugging confidence while away from keyboard.
+
+Scope:
+- Add server-side counters for common failures/timeouts/reconnects.
+- Expose in `/admin/status` and UI status cards.
+- Include recent run timeline snippets from event log.
+
+Acceptance criteria:
+- Admin shows counts for recent failures by class (auth, network, timeout, process exit).
+- Admin timeline shows recent operational milestones and errors with timestamps.
+
+Suggested labels:
+- `type:feature`, `priority:p1`, `area:local-orbit`, `area:ui`
+
+## P2 — Usability and Orchestration
+
+### 3) Away mode notifications for blocked turns
+
+Issue: #107
+
+Issue title:
+- `Away mode: push notification when turn is blocked on approval or user input`
+
+Why:
+- Enables practical long-running remote use without constantly watching the screen.
+
+Scope:
+- Trigger PWA/local notifications when thread indicator transitions to blocked.
+- Include quick deep-link to blocked thread.
+- Add per-device setting controls.
+
+Acceptance criteria:
+- When a turn reaches pending approval/user-input, notification fires once.
+- Tapping notification opens the corresponding thread.
+- User can disable/enable behavior from Settings.
+
+Suggested labels:
+- `type:feature`, `priority:p2`, `area:ui`
+
+### 4) Prompt/agent presets with import/export
+
+Issue: #108
+
+Issue title:
+- `Orchestration UX: prompt and agent presets with import/export`
+
+Why:
+- Reuses repeated workflows and makes collaboration mode practical.
+
+Scope:
+- Add preset schema (name, mode, model, reasoning effort, developer instructions, starter prompt).
+- Add Settings management UI.
+- Add import/export JSON.
+- Add dropdown apply in composer.
+
+Acceptance criteria:
+- User can create/edit/delete presets.
+- User can export presets and import on another device.
+- User can apply preset in one action before starting/sending.
+
+Suggested labels:
+- `type:feature`, `priority:p2`, `area:ui`, `area:protocol`
+
+## P3 — Advanced Multi-Agent Workflows
+
+### 5) First-class helper-agent orchestration
+
+Issue: #109
+
+Issue title:
+- `Multi-agent: first-class helper agent actions and profile-based spawn`
+
+Why:
+- Existing collab event plumbing exists; this converts it into an intentional user feature.
+
+Scope:
+- Add explicit UI action to spawn helper agent from selected profile.
+- Show helper-agent lifecycle and status in thread timeline.
+- Persist reusable helper profiles tied to presets.
+
+Acceptance criteria:
+- User can launch helper agent from UI without manual prompt crafting.
+- Timeline shows helper agent start/progress/completion clearly.
+- Profiles are reusable across sessions.
+
+Suggested labels:
+- `type:feature`, `priority:p3`, `area:ui`, `area:protocol`
+
+## Recommended Issue Creation Order
+
+1. Durable outbox + idempotency
+2. Run timeline + failure counters
+3. Away mode notifications
+4. Prompt/agent presets import/export
+5. First-class helper-agent orchestration


### PR DESCRIPTION
## Summary
- makes GitHub Issues + Project 2 explicit canonical trackers in repo docs
- adds issue templates (bug + feature) and disables blank issues
- adds prioritized recommendations document and links active items in backlog
- seeds backlog entries with issue IDs (#105-#109)

## Why
Ensure project backlog and issue tracking are consistently managed in GitHub and that recommendations are actionable as issues.

## Linked Work
Refs #105
Refs #106
Refs #107
Refs #108
Refs #109

## Validation
- docs/markdown and issue template files reviewed
- GitHub labels seeded (`type:*`, `priority:*`, `area:*`)
- issues #105-#109 created and added to Project 2
