### PR TITLE
feat(reliability): durable outbox + clientRequestId dedupe

### DIFF
--- a/src/lib/messages.svelte.ts
+++ b/src/lib/messages.svelte.ts
@@ -153,7 +153,7 @@ class MessagesStore {
       return { success: true };
     }
 
-    const result = socket.send({
+    const result = socket.sendReliable({
       method: "turn/interrupt",
       id: Date.now(),
       params: { threadId, turnId },
@@ -283,7 +283,7 @@ class MessagesStore {
 
     // Send JSON-RPC response with decision enum per Codex protocol (lowercase!)
     const decision = forSession ? "acceptForSession" : "accept";
-    socket.send({
+    socket.sendReliable({
       id: approval.rpcId,
       result: { decision, ...(collaborationMode ? { collaborationMode } : {}) },
     });
@@ -298,7 +298,7 @@ class MessagesStore {
     this.#updateApprovalInMessages(approvalId, "declined");
 
     // Decline = deny but let agent continue
-    socket.send({
+    socket.sendReliable({
       id: approval.rpcId,
       result: { decision: "decline", ...(collaborationMode ? { collaborationMode } : {}) },
     });
@@ -313,7 +313,7 @@ class MessagesStore {
     this.#updateApprovalInMessages(approvalId, "cancelled");
 
     // Cancel = deny and interrupt turn
-    socket.send({
+    socket.sendReliable({
       id: approval.rpcId,
       result: { decision: "cancel" },
     });
@@ -336,7 +336,7 @@ class MessagesStore {
       formattedAnswers[questionId] = { answers: selected };
     }
 
-    socket.send({
+    socket.sendReliable({
       id: msg.userInputRequest.rpcId,
       result: { answers: formattedAnswers, ...(collaborationMode ? { collaborationMode } : {}) },
     });

--- a/src/lib/threads.svelte.ts
+++ b/src/lib/threads.svelte.ts
@@ -318,7 +318,7 @@ class ThreadsStore {
     const id = this.#nextId++;
     this.#pendingRequests.set(id, "archive");
     socket.unsubscribeThread(threadId);
-    socket.send({
+    socket.sendReliable({
       method: "thread/archive",
       id,
       params: { threadId },
@@ -442,7 +442,7 @@ class ThreadsStore {
       navigate("/thread/:id", { params: { id: thread.id } });
     }
     if (this.#pendingStartInput) {
-      socket.send({
+      socket.sendReliable({
         method: "turn/start",
         id: this.#nextId++,
         params: {
@@ -499,7 +499,7 @@ class ThreadsStore {
     this.#pendingCollaborationMode = options?.collaborationMode ?? null;
     this.#pendingStartCallback = options?.onThreadStarted ?? null;
     this.#suppressNextNavigation = options?.suppressNavigation ?? false;
-    socket.send({
+    socket.sendReliable({
       method: "thread/start",
       id,
       params: {

--- a/src/routes/Thread.svelte
+++ b/src/routes/Thread.svelte
@@ -512,7 +512,7 @@
             );
         }
 
-        const result = socket.send({
+        const result = socket.sendReliable({
             method: "turn/start",
             id: Date.now(),
             params,


### PR DESCRIPTION
## Summary
- adds a durable reliable-send outbox in `src/lib/socket.svelte.ts`
- tags reliable mutation messages with `clientRequestId`
- flushes queued reliable messages on reconnect
- routes mutation sends through reliable transport (`thread/start`, `turn/start`, `thread/archive`, `turn/interrupt`, approval/user-input responses)
- adds relay-side duplicate suppression in local-orbit using `clientRequestId` TTL cache

## Why
Implements first delivery slice of #105 to prevent lost/duplicated mutating actions around reconnects.

## Linked Work
Refs #105

## Validation
- `npm run build` (pass)
