### PR TITLE
Orchestration UX: prompt and agent presets with import/export

### DIFF
--- a/src/lib/presets.ts
+++ b/src/lib/presets.ts
@@ -1,0 +1,116 @@
+import type { ModeKind, ReasoningEffort } from "./types";
+
+export type AgentPreset = {
+  id: string;
+  name: string;
+  mode: ModeKind;
+  model: string;
+  reasoningEffort: ReasoningEffort;
+  developerInstructions: string;
+  starterPrompt: string;
+};
+
+export const AGENT_PRESETS_STORAGE_KEY = "codex_pocket_agent_presets_v1";
+export const MAX_AGENT_PRESETS = 24;
+
+function generatePresetId(): string {
+  const randomPart = Math.random().toString(36).slice(2, 10);
+  return `preset_${Date.now().toString(36)}_${randomPart}`;
+}
+
+function normalizeMode(value: unknown): ModeKind {
+  return value === "plan" ? "plan" : "code";
+}
+
+function normalizeReasoning(value: unknown): ReasoningEffort {
+  if (value === "low" || value === "high" || value === "medium") {
+    return value;
+  }
+  return "medium";
+}
+
+function normalizeText(value: unknown, maxLen: number): string {
+  if (typeof value !== "string") return "";
+  return value.replace(/[\u0000\r]/g, "").slice(0, maxLen).trim();
+}
+
+function normalizeMultilineText(value: unknown, maxLen: number): string {
+  if (typeof value !== "string") return "";
+  return value.replace(/\u0000/g, "").slice(0, maxLen).trim();
+}
+
+export function normalizeAgentPresets(raw: unknown): AgentPreset[] {
+  if (!Array.isArray(raw)) return [];
+  const out: AgentPreset[] = [];
+  const seenIds = new Set<string>();
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue;
+    const record = item as Record<string, unknown>;
+    const name = normalizeText(record.name, 64);
+    const model = normalizeText(record.model, 120);
+    if (!name) continue;
+
+    let id = normalizeText(record.id, 80);
+    if (!id || seenIds.has(id)) {
+      id = generatePresetId();
+    }
+    seenIds.add(id);
+
+    out.push({
+      id,
+      name,
+      mode: normalizeMode(record.mode),
+      model,
+      reasoningEffort: normalizeReasoning(record.reasoningEffort),
+      developerInstructions: normalizeMultilineText(record.developerInstructions, 4000),
+      starterPrompt: normalizeMultilineText(record.starterPrompt, 4000),
+    });
+
+    if (out.length >= MAX_AGENT_PRESETS) break;
+  }
+  return out;
+}
+
+export function loadAgentPresets(): AgentPreset[] {
+  try {
+    const raw = localStorage.getItem(AGENT_PRESETS_STORAGE_KEY);
+    if (!raw) return [];
+    return normalizeAgentPresets(JSON.parse(raw));
+  } catch {
+    return [];
+  }
+}
+
+export function saveAgentPresets(presets: AgentPreset[]): AgentPreset[] {
+  const normalized = normalizeAgentPresets(presets);
+  try {
+    localStorage.setItem(AGENT_PRESETS_STORAGE_KEY, JSON.stringify(normalized));
+  } catch {
+    // ignore localStorage write errors
+  }
+  return normalized;
+}
+
+export function exportAgentPresetsJson(presets: AgentPreset[]): string {
+  return JSON.stringify(
+    {
+      version: 1,
+      exportedAt: new Date().toISOString(),
+      presets: normalizeAgentPresets(presets),
+    },
+    null,
+    2,
+  );
+}
+
+export function importAgentPresetsJson(text: string): AgentPreset[] {
+  const parsed = JSON.parse(text) as unknown;
+  if (Array.isArray(parsed)) {
+    return normalizeAgentPresets(parsed);
+  }
+  if (parsed && typeof parsed === "object") {
+    const data = (parsed as { presets?: unknown }).presets;
+    return normalizeAgentPresets(data);
+  }
+  return [];
+}

--- a/src/lib/threads.svelte.ts
+++ b/src/lib/threads.svelte.ts
@@ -11,6 +11,7 @@ const DEFAULT_SETTINGS: ThreadSettings = {
   reasoningEffort: "medium",
   sandbox: "workspace-write",
   mode: "code",
+  developerInstructions: "",
 };
 
 function lastPathSegment(input: string | undefined): string | undefined {
@@ -188,7 +189,8 @@ class ThreadsStore {
       current.model === next.model &&
       current.reasoningEffort === next.reasoningEffort &&
       current.sandbox === next.sandbox &&
-      current.mode === next.mode
+      current.mode === next.mode &&
+      current.developerInstructions === next.developerInstructions
     ) {
       return;
     }
@@ -300,15 +302,19 @@ class ThreadsStore {
     mode: ModeKind,
     model: string,
     reasoningEffort?: ReasoningEffort,
+    developerInstructions?: string,
   ): CollaborationMode {
     const preset = this.#collaborationPresets.find((p) => p.mode === mode);
+    const normalizedDeveloperInstructions = (developerInstructions ?? "").trim();
     return {
       mode,
       settings: {
         model,
         ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
-        ...(preset?.developer_instructions
-          ? { developer_instructions: preset.developer_instructions }
+        ...(normalizedDeveloperInstructions
+          ? { developer_instructions: normalizedDeveloperInstructions }
+          : preset?.developer_instructions
+            ? { developer_instructions: preset.developer_instructions }
           : {}),
       },
     };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,6 +39,17 @@ export interface ThreadSettings {
   reasoningEffort: ReasoningEffort;
   sandbox: SandboxMode;
   mode: ModeKind;
+  developerInstructions: string;
+}
+
+export interface AgentPreset {
+  id: string;
+  name: string;
+  mode: ModeKind;
+  model: string;
+  reasoningEffort: ReasoningEffort;
+  developerInstructions: string;
+  starterPrompt: string;
 }
 
 export type MessageRole = "user" | "assistant" | "tool" | "approval";


### PR DESCRIPTION
Fixes #108

## Summary
- add preset schema/storage for mode, model, reasoning, developer instructions, and starter prompt
- add Settings management UI for create/edit/delete plus JSON import/export
- add composer preset dropdown apply flow to set mode/model/reasoning and prefill starter prompt
- persist per-thread developer instructions and pass override into collaboration mode resolution

## Validation
- npm run build