### PR TITLE
Phase 4.2: Capability-based graceful degrade UX

### DIFF
--- a/src/lib/components/PromptInput.svelte
+++ b/src/lib/components/PromptInput.svelte
@@ -15,6 +15,7 @@
     modelOptions?: ModelOption[];
     modelsLoading?: boolean;
     disabled?: boolean;
+    disabledReason?: string;
     loading?: boolean;
     error?: string;
     draftKey?: string;
@@ -43,6 +44,7 @@
     modelOptions = [],
     modelsLoading = false,
     disabled = false,
+    disabledReason = "",
     loading = false,
     error = "",
     draftKey,
@@ -84,6 +86,7 @@
   let uploadBusy = $state(false);
   let uploadError = $state<string | null>(null);
   let pendingAttachments = $state<ImageAttachment[]>([]);
+  const resolvedDisabledReason = $derived((disabledReason ?? "").trim());
 
   const canAttach = $derived(canAttachFiles(thread));
   const canSubmit = $derived((input.trim().length > 0 || pendingAttachments.length > 0) && !disabled && !loading);
@@ -298,6 +301,7 @@
       placeholder="What would you like to do?"
       rows="1"
       disabled={disabled || loading}
+      title={resolvedDisabledReason}
 	    ></textarea>
     {#if pendingAttachments.length}
       <div class="attachment-chips" role="list" aria-label="Selected attachments">
@@ -543,7 +547,12 @@
           </svg>
         </button>
       {:else}
-        <button type="submit" class="submit-btn row" disabled={!canSubmit}>
+        <button
+          type="submit"
+          class="submit-btn row"
+          disabled={!canSubmit}
+          title={resolvedDisabledReason || "Send"}
+        >
           {#if disabled || loading}
             <svg class="spinner" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <path d="M21 12a9 9 0 1 1-6.219-8.56"/>
@@ -557,6 +566,9 @@
         </button>
       {/if}
     </div>
+    {#if resolvedDisabledReason}
+      <div class="hint" style="padding: 0 var(--space-md) var(--space-sm);">{resolvedDisabledReason}</div>
+    {/if}
     {#if uploadError}
       <div class="hint hint-error" style="padding: 0 var(--space-md) var(--space-sm);">{uploadError}</div>
     {/if}

--- a/src/lib/thread-capabilities.ts
+++ b/src/lib/thread-capabilities.ts
@@ -57,6 +57,23 @@ export function supportsStreaming(thread: ThreadInfo | null | undefined): boolea
 }
 
 /**
+ * Checks if a thread supports sending prompts.
+ * Defaults to true if capabilities are undefined (backward compatibility).
+ *
+ * @param thread - The thread to check capabilities for
+ * @returns boolean indicating if prompt input is supported
+ */
+export function canSendPrompt(thread: ThreadInfo | null | undefined): boolean {
+  if (!thread || !thread.capabilities) {
+    return true;
+  }
+  if (typeof thread.capabilities.sendPrompt === 'boolean') {
+    return thread.capabilities.sendPrompt;
+  }
+  return true;
+}
+
+/**
  * Returns a tooltip message for a disabled capability.
  * Returns an empty string if the capability is available.
  *
@@ -78,6 +95,9 @@ export function getCapabilityTooltip(capability: keyof ProviderCapabilities | st
       return 'This provider does not support interactive approvals';
     case 'SUPPORTS_STREAMING':
       return 'This provider does not support live streaming updates';
+    case 'SEND_PROMPT':
+    case 'sendPrompt':
+      return 'This provider does not allow sending prompts in this session';
     default:
       return 'This capability is not supported by the current provider';
   }

--- a/src/lib/threads.svelte.ts
+++ b/src/lib/threads.svelte.ts
@@ -62,24 +62,47 @@ function repoNameFromOrigin(origin: string | undefined): string | undefined {
 }
 
 
-function parseCapabilities(input: any): ProviderCapabilities | null {
+function parseCapabilities(input: any): ProviderCapabilities & Partial<ThreadCapabilities> | null {
   const thread = input && typeof input === "object" ? input : {};
   const source = thread.capabilities && typeof thread.capabilities === "object" ? thread.capabilities : thread;
-  const canAttachFiles = typeof source?.CAN_ATTACH_FILES === "boolean" ? source.CAN_ATTACH_FILES : null;
-  const canFilterHistory = typeof source?.CAN_FILTER_HISTORY === "boolean" ? source.CAN_FILTER_HISTORY : null;
-  const supportsApprovals = typeof source?.SUPPORTS_APPROVALS === "boolean" ? source.SUPPORTS_APPROVALS : null;
-  const supportsStreaming = typeof source?.SUPPORTS_STREAMING === "boolean" ? source.SUPPORTS_STREAMING : null;
+  const canAttachFiles =
+    typeof source?.CAN_ATTACH_FILES === "boolean"
+      ? source.CAN_ATTACH_FILES
+      : typeof source?.attachments === "boolean"
+        ? source.attachments
+        : null;
+  const canFilterHistory =
+    typeof source?.CAN_FILTER_HISTORY === "boolean"
+      ? source.CAN_FILTER_HISTORY
+      : typeof source?.filtering === "boolean"
+        ? source.filtering
+        : null;
+  const supportsApprovals =
+    typeof source?.SUPPORTS_APPROVALS === "boolean"
+      ? source.SUPPORTS_APPROVALS
+      : typeof source?.approvals === "boolean"
+        ? source.approvals
+        : null;
+  const supportsStreaming =
+    typeof source?.SUPPORTS_STREAMING === "boolean"
+      ? source.SUPPORTS_STREAMING
+      : typeof source?.streaming === "boolean"
+        ? source.streaming
+        : null;
+  const sendPrompt = typeof source?.sendPrompt === "boolean" ? source.sendPrompt : null;
   const hasAny =
     canAttachFiles != null ||
     canFilterHistory != null ||
     supportsApprovals != null ||
-    supportsStreaming != null;
+    supportsStreaming != null ||
+    sendPrompt != null;
   if (!hasAny) return null;
   return {
     CAN_ATTACH_FILES: canAttachFiles ?? DEFAULT_CAPABILITIES.CAN_ATTACH_FILES,
     CAN_FILTER_HISTORY: canFilterHistory ?? DEFAULT_CAPABILITIES.CAN_FILTER_HISTORY,
     SUPPORTS_APPROVALS: supportsApprovals ?? DEFAULT_CAPABILITIES.SUPPORTS_APPROVALS,
     SUPPORTS_STREAMING: supportsStreaming ?? DEFAULT_CAPABILITIES.SUPPORTS_STREAMING,
+    sendPrompt: sendPrompt ?? DEFAULT_CAPABILITIES.sendPrompt,
   };
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -32,7 +32,7 @@ export interface ThreadInfo {
   provider: "codex" | "copilot-acp";
   status?: string;
   archived: boolean;
-  capabilities?: ProviderCapabilities;
+  capabilities?: ProviderCapabilities & Partial<ThreadCapabilities>;
 }
 
 export interface ProviderCapabilities {

--- a/src/routes/Home.svelte
+++ b/src/routes/Home.svelte
@@ -7,6 +7,7 @@
   import { models } from "../lib/models.svelte";
   import { theme } from "../lib/theme.svelte";
   import { auth } from "../lib/auth.svelte";
+  import { canSendPrompt, getCapabilityTooltip } from "../lib/thread-capabilities";
   import AppHeader from "../lib/components/AppHeader.svelte";
   import ProjectPicker from "../lib/components/ProjectPicker.svelte";
   import ShimmerDot from "../lib/components/ShimmerDot.svelte";
@@ -621,7 +622,7 @@
   }
 </script>
 
-{#snippet threadSection(groups: any[], readonly = false)}
+{#snippet threadSection(groups: any[])}
   {#if groups.length > 0}
     {#each groups as group (group.label)}
       <div class="thread-group stack">
@@ -641,6 +642,8 @@
             {#each group.threads as thread (thread.id)}
               {@const repoLabel = threadRepoLabel(thread)}
               {@const projectLabel = threadProjectLabel(thread)}
+              {@const canManageThread = canSendPrompt(thread)}
+              {@const disabledReason = canManageThread ? "" : getCapabilityTooltip("SEND_PROMPT", false)}
               <li class="thread-item row">
                 <a
                   class="thread-link row"
@@ -717,16 +720,16 @@
                 <button
                   class="thread-action-btn rename-btn"
                   onclick={() => renameThread(thread)}
-                  disabled={readonly}
-                  title="Rename thread"
+                  disabled={!canManageThread}
+                  title={canManageThread ? "Rename thread" : disabledReason}
                 >
                   ✏️
                 </button>
                 <button
                   class="thread-action-btn archive-btn"
                   onclick={() => threads.archive(thread.id)}
-                  disabled={readonly}
-                  title="Archive thread"
+                  disabled={!canManageThread}
+                  title={canManageThread ? "Archive thread" : disabledReason}
                 >
                   📦
                 </button>
@@ -915,7 +918,7 @@
           </div>
 
           {#if copilotGrouped.groups.length > 0}
-            {@render threadSection(copilotGrouped.groups, true)}
+            {@render threadSection(copilotGrouped.groups)}
           {:else}
             <div class="empty-state">No Copilot sessions detected</div>
           {/if}


### PR DESCRIPTION
## Summary
- move prompt input gating to capability checks and surface disabled reasons
- drive thread action disabling from capabilities instead of provider checks
- parse legacy capability flags (including sendPrompt) for backward compatibility

## Testing
- bun run check (fails: script not found)
- bun run build
- bun test

## Acceptance Criteria
- No hard-coded provider read-only checks for Phase 4 surfaces
- Unsupported controls disabled with visible reason hints
- Supported controls unchanged for Codex and ACP Phase 2

Closes #152