### PR TITLE
Phase 5: Claude Adapter Foundation (#200)

### DIFF
--- a/services/local-orbit/src/providers/adapters/__tests__/claude-adapter.test.ts
+++ b/services/local-orbit/src/providers/adapters/__tests__/claude-adapter.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for Claude Provider Adapter (foundation scaffold)
+ *
+ * These tests verify the Claude adapter's foundation implementation:
+ * - Adapter interface compliance
+ * - Health check graceful degradation
+ * - Capability declaration
+ */
+
+import { describe, it, expect, beforeEach } from "bun:test";
+import { ClaudeAdapter } from "../claude-adapter";
+
+describe("ClaudeAdapter - Foundation", () => {
+  let adapter: ClaudeAdapter;
+
+  beforeEach(() => {
+    adapter = new ClaudeAdapter();
+  });
+
+  describe("adapter interface", () => {
+    it("has correct providerId", () => {
+      expect(adapter.providerId).toBe("claude");
+    });
+
+    it("has correct providerName", () => {
+      expect(adapter.providerName).toBe("Claude");
+    });
+
+    it("declares capabilities", () => {
+      expect(adapter.capabilities).toBeDefined();
+      expect(typeof adapter.capabilities.listSessions).toBe("boolean");
+      expect(typeof adapter.capabilities.streaming).toBe("boolean");
+      expect(typeof adapter.capabilities.attachments).toBe("boolean");
+    });
+  });
+
+  describe("lifecycle methods", () => {
+    it("starts without errors", async () => {
+      await adapter.start();
+      // No assertion - just verify no errors thrown
+    });
+
+    it("stops without errors", async () => {
+      await adapter.stop();
+      // No assertion - just verify no errors thrown
+    });
+
+    it("can be started and stopped multiple times", async () => {
+      await adapter.start();
+      await adapter.stop();
+      await adapter.start();
+      await adapter.stop();
+      // No assertion - just verify no errors thrown
+    });
+  });
+
+  describe("health check", () => {
+    it("returns unhealthy status in foundation phase", async () => {
+      const health = await adapter.health();
+      
+      expect(health.status).toBe("unhealthy");
+      expect(health.message).toContain("foundation");
+      expect(health.lastCheck).toBeDefined();
+    });
+
+    it("includes foundation phase details", async () => {
+      const health = await adapter.health();
+      
+      expect(health.details).toBeDefined();
+      expect(health.details?.reason).toBe("foundation_scaffold");
+      expect(health.details?.phase).toBe("P5-01");
+    });
+
+    it("indicates API key configuration status", async () => {
+      const adapterWithKey = new ClaudeAdapter({ apiKey: "test-key" });
+      const healthWithKey = await adapterWithKey.health();
+      
+      expect(healthWithKey.details?.apiKeyConfigured).toBe(true);
+
+      const adapterNoKey = new ClaudeAdapter();
+      const healthNoKey = await adapterNoKey.health();
+      
+      expect(healthNoKey.details?.apiKeyConfigured).toBe(false);
+    });
+  });
+
+  describe("session operations (not implemented)", () => {
+    it("listSessions returns empty result", async () => {
+      const result = await adapter.listSessions();
+      
+      expect(result.sessions).toEqual([]);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it("openSession throws not implemented error", async () => {
+      await expect(adapter.openSession("test-session")).rejects.toThrow(
+        /not implemented/i
+      );
+    });
+
+    it("sendPrompt throws not implemented error", async () => {
+      await expect(
+        adapter.sendPrompt("test-session", { text: "test" })
+      ).rejects.toThrow(/not implemented/i);
+    });
+
+    it("subscribe throws not implemented error", async () => {
+      await expect(
+        adapter.subscribe("test-session", () => {})
+      ).rejects.toThrow(/not implemented/i);
+    });
+
+    it("unsubscribe completes without error", async () => {
+      const subscription = {
+        id: "sub-123",
+        sessionId: "test-session",
+        provider: "claude" as const,
+        unsubscribe: async () => {},
+      };
+      await adapter.unsubscribe(subscription);
+      // No assertion - just verify no errors thrown
+    });
+
+    it("normalizeEvent returns null", async () => {
+      const result = await adapter.normalizeEvent({ type: "test" });
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("configuration", () => {
+    it("accepts configuration options", () => {
+      const adapterWithConfig = new ClaudeAdapter({
+        apiKey: "test-key",
+        baseUrl: "https://api.anthropic.com",
+        timeout: 60000,
+        model: "claude-3-opus",
+      });
+
+      expect(adapterWithConfig).toBeDefined();
+    });
+
+    it("uses default configuration when not provided", () => {
+      const adapterDefaults = new ClaudeAdapter();
+      expect(adapterDefaults).toBeDefined();
+    });
+  });
+
+  describe("capability reporting", () => {
+    it("reports streaming capability as true", () => {
+      expect(adapter.capabilities.streaming).toBe(true);
+    });
+
+    it("reports attachments capability as true", () => {
+      expect(adapter.capabilities.attachments).toBe(true);
+    });
+
+    it("reports unimplemented capabilities as false", () => {
+      expect(adapter.capabilities.listSessions).toBe(false);
+      expect(adapter.capabilities.openSession).toBe(false);
+      expect(adapter.capabilities.sendPrompt).toBe(false);
+      expect(adapter.capabilities.approvals).toBe(false);
+      expect(adapter.capabilities.filtering).toBe(false);
+      expect(adapter.capabilities.pagination).toBe(false);
+    });
+
+    it("reports multiTurn capability as true (future support)", () => {
+      expect(adapter.capabilities.multiTurn).toBe(true);
+    });
+  });
+});

--- a/services/local-orbit/src/providers/adapters/claude-adapter.ts
+++ b/services/local-orbit/src/providers/adapters/claude-adapter.ts
@@ -1,0 +1,178 @@
+/**
+ * Claude Provider Adapter
+ *
+ * Foundation scaffold for Claude integration following the provider adapter pattern.
+ * This is a Phase 5 foundation-only implementation - full API integration deferred.
+ *
+ * Phase 5 scope (foundation):
+ * - Adapter interface implementation (scaffold)
+ * - Health check wiring (returns false gracefully)
+ * - Capability declaration
+ * - Registry integration
+ *
+ * Future phases:
+ * - Claude API/CLI integration
+ * - Session listing and normalization
+ * - Prompt send and streaming
+ * - Event normalization
+ */
+
+import type { ProviderAdapter } from "../contracts.js";
+import type {
+  ProviderCapabilities,
+  ProviderHealthStatus,
+  SessionListResult,
+  SessionFilters,
+  NormalizedSession,
+  PromptInput,
+  PromptOptions,
+  EventSubscription,
+  NormalizedEvent,
+} from "../provider-types.js";
+
+/**
+ * Configuration for Claude adapter
+ */
+export interface ClaudeConfig {
+  /**
+   * Optional Claude API key for authentication
+   */
+  apiKey?: string;
+
+  /**
+   * Optional Claude API base URL (default: Anthropic public API)
+   */
+  baseUrl?: string;
+
+  /**
+   * Optional timeout for Claude API operations in milliseconds
+   */
+  timeout?: number;
+
+  /**
+   * Optional Claude model to use (e.g., "claude-3-opus", "claude-3-sonnet")
+   */
+  model?: string;
+}
+
+/**
+ * Claude Provider Adapter implementation (foundation scaffold)
+ */
+export class ClaudeAdapter implements ProviderAdapter {
+  readonly providerId = "claude";
+  readonly providerName = "Claude";
+
+  readonly capabilities: ProviderCapabilities = {
+    listSessions: false,      // Phase 6+
+    openSession: false,       // Phase 6+
+    sendPrompt: false,        // Phase 6+
+    streaming: true,          // Claude API supports streaming (capability exists)
+    attachments: true,        // Claude supports vision/attachments (capability exists)
+    approvals: false,         // TBD based on implementation approach
+    multiTurn: true,          // Claude supports multi-turn conversations (capability exists)
+    filtering: false,         // Phase 6+
+    pagination: false,        // Phase 6+
+  };
+
+  private config: ClaudeConfig;
+
+  constructor(config: ClaudeConfig = {}) {
+    this.config = {
+      timeout: 30000,
+      model: "claude-3-5-sonnet-20241022", // Latest stable model
+      ...config,
+    };
+  }
+
+  /**
+   * Start the Claude adapter.
+   * Foundation implementation - no actual startup required yet.
+   */
+  async start(): Promise<void> {
+    console.log("[claude] Adapter started (foundation-only, no API integration)");
+    // Future: Initialize Claude API client, validate credentials
+  }
+
+  /**
+   * Stop the Claude adapter and clean up resources.
+   */
+  async stop(): Promise<void> {
+    console.log("[claude] Adapter stopped");
+    // Future: Clean up any persistent connections or subscriptions
+  }
+
+  /**
+   * Check health status of the Claude adapter.
+   * Foundation implementation returns unhealthy gracefully until full integration.
+   */
+  async health(): Promise<ProviderHealthStatus> {
+    return {
+      status: "unhealthy",
+      message: "Claude adapter foundation-only (no API integration yet)",
+      lastCheck: new Date().toISOString(),
+      details: {
+        reason: "foundation_scaffold",
+        phase: "P5-01",
+        apiKeyConfigured: !!this.config.apiKey,
+      },
+    };
+  }
+
+  /**
+   * List sessions/conversations from Claude.
+   * Not implemented in foundation phase.
+   */
+  async listSessions(_cursor?: string, _filters?: SessionFilters): Promise<SessionListResult> {
+    return {
+      sessions: [],
+      hasMore: false,
+    };
+  }
+
+  /**
+   * Open/resume a specific Claude conversation.
+   * Not implemented in foundation phase.
+   */
+  async openSession(sessionId: string): Promise<NormalizedSession> {
+    throw new Error(`Claude adapter foundation-only: openSession(${sessionId}) not implemented`);
+  }
+
+  /**
+   * Send a prompt to a Claude conversation.
+   * Not implemented in foundation phase.
+   */
+  async sendPrompt(
+    sessionId: string,
+    _input: PromptInput,
+    _options?: PromptOptions,
+  ): Promise<{ turnId?: string; requestId?: string; [key: string]: unknown }> {
+    throw new Error(`Claude adapter foundation-only: sendPrompt(${sessionId}) not implemented`);
+  }
+
+  /**
+   * Subscribe to realtime events from a Claude conversation.
+   * Not implemented in foundation phase.
+   */
+  async subscribe(
+    sessionId: string,
+    _callback: (event: NormalizedEvent) => void,
+  ): Promise<EventSubscription> {
+    throw new Error(`Claude adapter foundation-only: subscribe(${sessionId}) not implemented`);
+  }
+
+  /**
+   * Unsubscribe from conversation events.
+   */
+  async unsubscribe(_subscription: EventSubscription): Promise<void> {
+    // No-op for foundation scaffold
+  }
+
+  /**
+   * Normalize a raw Claude event into the unified event envelope.
+   * Not implemented in foundation phase.
+   */
+  async normalizeEvent(_rawEvent: unknown): Promise<NormalizedEvent | null> {
+    // No events to normalize in foundation phase
+    return null;
+  }
+}

--- a/services/local-orbit/src/providers/adapters/index.ts
+++ b/services/local-orbit/src/providers/adapters/index.ts
@@ -6,5 +6,6 @@
 
 export { CopilotAcpAdapter, type CopilotAcpConfig } from "./copilot-acp-adapter.js";
 export { CodexAdapter, type CodexConfig } from "./codex-adapter.js";
+export { ClaudeAdapter, type ClaudeConfig } from "./claude-adapter.js";
 export { AcpClient } from "./acp-client.js";
 export { findExecutable, spawnProcess, killProcess, processHealth } from "./process-utils.js";

--- a/services/local-orbit/src/providers/provider-types.ts
+++ b/services/local-orbit/src/providers/provider-types.ts
@@ -8,7 +8,7 @@
 /**
  * Provider identifier literals for type safety
  */
-export type ProviderId = "codex" | "copilot-acp" | string;
+export type ProviderId = "codex" | "copilot-acp" | "claude" | string;
 
 /**
  * Session/thread status across providers


### PR DESCRIPTION
Foundation-only implementation of Claude provider adapter following existing ACP pattern.

Related: #200
Packet: p2-02-claude-adapter-foundation

Changes:
- Created ClaudeAdapter class with ProviderAdapter interface compliance
- Defined capability matrix for Claude
- Registered in provider registry (disabled by default)
- Added health check returning graceful degradation
- 21 tests all passing

Validation:
✓ Type check passes
✓ Build succeeds  
✓ Tests pass (21/21)

No API integration yet - foundation only.