### PR TITLE
fix: Replace insecure Math.random()/Date.now() session IDs with crypto.randomUUID()

### DIFF
--- a/services/local-orbit/src/providers/adapters/copilot-acp-adapter.ts
+++ b/services/local-orbit/src/providers/adapters/copilot-acp-adapter.ts
@@ -217,7 +217,7 @@ export class CopilotAcpAdapter implements ProviderAdapter {
           const key = String(rpcId);
           const sessionId = typeof params.sessionId === "string" && params.sessionId
             ? params.sessionId
-            : `anon-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+            : `anon-${crypto.randomUUID()}`;
           const threadId = `copilot-acp:${sessionId}`;
 
           const timeoutHandle = setTimeout(() => {
@@ -840,7 +840,7 @@ export class CopilotAcpAdapter implements ProviderAdapter {
   private normalizeSession(raw: any): NormalizedSession {
     return {
       provider: this.providerId,
-      sessionId: raw.id || raw.sessionId || String(Math.random()),
+      sessionId: raw.id || raw.sessionId || `session-${crypto.randomUUID()}`,
       title: raw.title || raw.name || "Untitled Session",
       project: raw.project || raw.workspace,
       repo: raw.repo || raw.repository,

--- a/services/local-orbit/src/providers/adapters/opencode-adapter.ts
+++ b/services/local-orbit/src/providers/adapters/opencode-adapter.ts
@@ -329,7 +329,7 @@ export class OpenCodeAdapter implements ProviderAdapter {
 
   private normalizeSession(raw: Record<string, unknown>): NormalizedSession {
     const now = new Date().toISOString();
-    const sessionId = this.pickString(raw, ["id", "sessionId", "session_id"]) ?? `opencode-${Date.now()}`;
+    const sessionId = this.pickString(raw, ["id", "sessionId", "session_id"]) ?? `opencode-${crypto.randomUUID()}`;
     const createdAt = this.pickString(raw, ["createdAt", "created_at", "created"]) ?? now;
     const updatedAt = this.pickString(raw, ["updatedAt", "updated_at", "updated", "lastUpdatedAt"]) ?? createdAt;
     const title = this.pickString(raw, ["title", "name"]) ?? "Untitled Session";


### PR DESCRIPTION
## Summary

- Replaces `Math.random().toString(36)` with `crypto.randomUUID()` in copilot-acp-adapter.ts (anonymous session fallback, line 220)
- Replaces `String(Math.random())` with `crypto.randomUUID()` in copilot-acp-adapter.ts (normalizeSession fallback, line 843)
- Replaces `Date.now()` with `crypto.randomUUID()` in opencode-adapter.ts (session fallback, line 332)

## Why

`Math.random()` is not cryptographically secure and produces predictable, low-entropy session identifiers. When used as fallback session IDs, this creates a risk where:
1. Empty sessionId values could produce collisions leading to shared threadIds across users
2. Predictable session IDs could be guessed by an attacker

`crypto.randomUUID()` generates RFC 4122 v4 UUIDs with 122 bits of cryptographic randomness, eliminating both collision and predictability risks.

## How to test

1. `bun run build` in `services/local-orbit/` — should compile with no errors
2. Start server, connect a Copilot or OpenCode provider without explicit session config
3. Verify generated session IDs are proper UUIDs (format: `xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx`)

## Risk assessment

**Low risk** — Only changes fallback paths that were already generating random-ish strings. The replacement produces strings in the same general category (random identifiers) but with proper cryptographic guarantees. No API surface changes.

## Rollback

Revert this single commit: `ec65ec9`

Fixes #290
Partially addresses #288 (session ID security items)