### PR TITLE
fix: add NaN guards, document codex adapter, update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,40 @@ The following features were added during early development:
 - CI now smoke-tests token-session security behavior (pairing returns per-device token, read-only session write/WS mutating guards).
 - CI now also verifies pair codes are one-time consumable and revoked session tokens immediately lose auth.
 
+## 2026-02-21
+
+### Fixed
+
+- fix: Address 33 Copilot review comments from merged PRs #280-286 (#294)
+- fix: Replace insecure Math.random()/Date.now() session IDs with crypto.randomUUID() (#293)
+
+## 2026-02-20
+
+### Added
+
+- feat: P5.4 plan mode visualization (#286)
+- feat: P5 polish & micro-interactions (#285)
+- feat: P4 conversation UI refresh (#284)
+- feat: P3 composer improvements (#283)
+- feat: P2 component library (#282, #281)
+- feat: P1 design system foundation (#280)
+
+### Fixed
+
+- fix: Remediate Copilot code review findings (#279)
+
+## 2026-02-18
+
+### Added
+
+- feat: Multi-provider routing and UI support (#275)
+
+## 2026-02-16
+
+### Security
+
+- security: Authorization, sanitization, validation, schema hardening (#267)
+
 ## 2026-02-17 - Phase 2: Multi-provider & Reliability
 
 ### Providers (Phase 2)

--- a/services/local-orbit/src/providers/adapters/codex-adapter.ts
+++ b/services/local-orbit/src/providers/adapters/codex-adapter.ts
@@ -1,8 +1,8 @@
 /**
  * Codex Provider Adapter
  *
- * This is a Phase 1 placeholder for the Codex app-server provider.
- * Currently implements basic health reporting and empty results for session listing.
+ * Phase 1 placeholder — listSessions returns empty, all other methods throw 'not implemented'.
+ * Full implementation planned for Phase 2.
  */
 
 import type { ProviderAdapter } from "../contracts.js";

--- a/src/lib/components/message/TokenCost.svelte
+++ b/src/lib/components/message/TokenCost.svelte
@@ -7,6 +7,7 @@
   const { totalTokens, estimatedCost }: Props = $props();
 
   function formatTokenCount(tokens: number): string {
+    if (!Number.isFinite(tokens)) return '—';
     if (tokens >= 1000) {
       const compact = (tokens / 1000).toFixed(1);
       return `${compact.replace(/\.0$/, "")}K`;

--- a/src/routes/Metrics.svelte
+++ b/src/routes/Metrics.svelte
@@ -50,10 +50,12 @@
   });
   
   function formatCost(cost: number): string {
+    if (!Number.isFinite(cost)) return '—';
     return `$${cost.toFixed(4)}`;
   }
   
   function formatNumber(num: number): string {
+    if (!Number.isFinite(num)) return '—';
     return num.toLocaleString();
   }
   


### PR DESCRIPTION
## Summary
- Add `Number.isFinite()` guards to 3 format functions (`formatTokenCount`, `formatCost`, `formatNumber`) that could render NaN/Infinity
- Document Codex adapter as Phase 1 placeholder with JSDoc
- Update CHANGELOG.md with entries for PRs #267–#294 (5 days of missing entries)

Closes #303

## How to test
- Pass `NaN`, `Infinity`, `-Infinity` to token/cost display — should render `—`
- Verify CHANGELOG entries match merged PR titles
- Verify Codex adapter JSDoc is clear about Phase 1 status

## Risk
Low — guard clauses are additive, CHANGELOG/JSDoc are documentation-only.

## Rollback
`git revert <commit>` — no migrations or state changes.