### PR TITLE
fix(claude-mcp): search ~/.local/bin and user dirs when finding executables

### DIFF
--- a/services/local-orbit/src/providers/adapters/claude-mcp-adapter.ts
+++ b/services/local-orbit/src/providers/adapters/claude-mcp-adapter.ts
@@ -198,7 +198,17 @@ export class ClaudeMcpAdapter implements ProviderAdapter {
         lastCheck: now,
         details: {
           reason: "executable_not_found",
-          searchedPaths: process.env.PATH?.split(":") || [],
+          searchedPaths: [
+            ...(process.env.PATH?.split(":") || []),
+            ...(process.env.HOME ? [
+              `${process.env.HOME}/.local/bin`,
+              `${process.env.HOME}/bin`,
+              `${process.env.HOME}/.npm-global/bin`,
+              `${process.env.HOME}/.yarn/bin`,
+            ] : []),
+            "/opt/homebrew/bin",
+            "/usr/local/bin",
+          ].filter((v, i, a) => a.indexOf(v) === i),
           installUrl: "https://docs.anthropic.com/claude/docs/cli",
         },
       };


### PR DESCRIPTION
## What / Why

The server process starts without `~/.local/bin` in its PATH, even though the user's interactive shell has it. The `claude` CLI installs to `~/.local/bin` by default, so the `findExecutable('claude')` call in the Claude MCP adapter returns null and reports the provider as degraded/\"not found\" — even when `which claude` works fine in the terminal.

## Changes

- **`process-utils.ts`**: `findExecutable()` now augments `process.env.PATH` with common user-local bin directories: `~/.local/bin`, `~/bin`, `~/.npm-global/bin`, `~/.yarn/bin`, `/opt/homebrew/bin`, `/usr/local/bin`. System PATH entries are checked first; extras are deduped.
- **`claude-mcp-adapter.ts`**: Updated `searchedPaths` in degraded health details to reflect the full list actually searched (so the Settings UI accurately shows what was tried).

## How to Test

1. Ensure `claude` is installed at `~/.local/bin/claude` and `which claude` works in terminal
2. Restart coderelay: `coderelay restart`
3. Check Settings → Providers — Claude MCP should now show **healthy** (or degraded for a different reason) instead of \"CLI not found in PATH\"
4. Or verify via: `curl -s -H "Authorization: Bearer <token>" http://127.0.0.1:8790/admin/status | python3 -m json.tool`

## Risk Assessment

Low. Change only affects which directories are searched — existing PATH search is preserved and takes priority. If `~/.local/bin` doesn't exist, `access()` simply returns not-found and the search continues.

## Rollback

Revert the `findExecutable` function to use `process.env.PATH` only, or pin to previous commit.