### PR TITLE
fix(mobile): fix overlapping copy/menu controls in message bubbles

### DIFF
--- a/src/lib/components/message/MessageActions.svelte
+++ b/src/lib/components/message/MessageActions.svelte
@@ -78,7 +78,7 @@
 {#if uiToggles.showMessageCopyButton}
   <button
     type="button"
-    class="absolute top-[6px] right-[10px] px-2.5 py-1 rounded-sm border border-cli-border bg-black/25 text-cli-text-muted font-mono text-[11px] cursor-pointer opacity-0 transition-all duration-200 hover:text-cli-text max-[520px]:opacity-100 max-[520px]:px-3 max-[520px]:py-1.5 max-[520px]:text-xs group-hover:opacity-100 focus-within:opacity-100"
+    class="absolute top-[6px] right-[42px] px-2.5 py-1 rounded-sm border border-cli-border bg-black/25 text-cli-text-muted font-mono text-[11px] cursor-pointer opacity-0 transition-all duration-200 hover:text-cli-text max-sm:hidden group-hover:opacity-100 focus-within:opacity-100"
     class:opacity-100={copyState !== "idle"}
     class:border-cli-success={copyState === "copied"}
     class:text-cli-success={copyState === "copied"}


### PR DESCRIPTION
## What

On narrow screens (< 640px), two absolutely-positioned controls landed in the same top-right corner of every message bubble:
- The inline `copy` text button (`absolute top-[6px] right-[10px]`, forced visible via `max-[520px]:opacity-100`)
- The `⋯` overflow menu button (`absolute top-xs right-md`, always visible)

This made both unusable on mobile — they overlapped into a single unreadable cluster.

## Why

The `copy` button was given `max-[520px]:opacity-100` to ensure quick access on mobile, but it was never offset from the `⋯` button, so they collided.

## Fix (1-line change in `MessageActions.svelte`)

- **Hide `copy` on mobile** (`max-sm:hidden`) — `Copy` is already in the `⋯` overflow menu, so it's fully accessible without the inline button
- **Offset `copy` on desktop** (`right-[42px]` instead of `right-[10px]`) — on desktop hover, `copy` and `⋯` now sit side-by-side cleanly

## How to test

1. Open a thread on mobile or DevTools at 375px width
2. Tap a message — only the `⋯` button should appear in the top-right, tap it to see Copy in the menu
3. On desktop, hover a message — `copy` and `⋯` appear side-by-side without overlap

## Risk

Low. CSS-only change, no logic touched. Desktop behavior unchanged except buttons no longer overlap on hover.

## Rollback

`git revert 1e7f373`