### PR TITLE
fix(home): hide non-matching provider sections when filter is active

### DIFF
--- a/src/routes/Home.svelte
+++ b/src/routes/Home.svelte
@@ -1096,7 +1096,7 @@
           </div>
         {/if}
 
-        <!-- Codex Provider Section -->
+        {#if filters.provider === "all" || filters.provider === "codex" || filters.provider === "claude"}
         <div class="provider-section">
           <div class="provider-header">
             <div class="provider-title">
@@ -1115,8 +1115,9 @@
             <div class="empty-state">No Codex threads yet</div>
           {/if}
         </div>
+        {/if}
 
-        <!-- Copilot Provider Section -->
+        {#if filters.provider === "all" || filters.provider === "copilot-acp"}
         <div class="provider-section">
           <div class="provider-header">
             <div class="provider-title">
@@ -1134,8 +1135,9 @@
             <div class="empty-state">No Copilot sessions detected</div>
           {/if}
         </div>
+        {/if}
 
-        <!-- OpenCode Provider Section -->
+        {#if filters.provider === "all" || filters.provider === "opencode"}
         <div class="provider-section">
           <div class="provider-header">
             <div class="provider-title">
@@ -1154,6 +1156,7 @@
             <div class="empty-state">No OpenCode sessions yet</div>
           {/if}
         </div>
+        {/if}
       {/if}
     </div>
   {/if}


### PR DESCRIPTION
## Summary
- When a specific provider filter is selected (e.g. Copilot), only that provider's section now renders
- Previously all three provider sections (Codex, GitHub Copilot, OpenCode) rendered regardless of filter, showing empty states for non-matching providers

## Changes
- `src/routes/Home.svelte` — wrapped each `provider-section` div in an `{#if}` block gated on `filters.provider`:
  - **Codex section**: shows when filter is `all`, `codex`, or `claude` (Claude threads route into the Codex bucket)
  - **Copilot section**: shows when filter is `all` or `copilot-acp`
  - **OpenCode section**: shows when filter is `all` or `opencode`

## How to test
1. Open the home page
2. Click "Copilot" filter tab — only the GitHub Copilot section should appear
3. Click "Codex" filter tab — only the Codex section should appear
4. Click "OpenCode" filter tab — only the OpenCode section should appear
5. Click "All" — all three sections should appear as before

## Risk assessment
Low — conditional rendering only, no data flow changes.

## Rollback
Revert this commit.